### PR TITLE
feat: per-instance finding granularity (RFC-142)

### DIFF
--- a/src/forge/__tests__/github-adapter.test.ts
+++ b/src/forge/__tests__/github-adapter.test.ts
@@ -63,6 +63,7 @@ describe('GitHubAdapter', () => {
         repo: 'repo',
         labels: 'rsolv:detected',
         state: 'open',
+        per_page: 100,
       });
 
       expect(result).toHaveLength(1);

--- a/src/forge/github-adapter.ts
+++ b/src/forge/github-adapter.ts
@@ -37,6 +37,7 @@ export class GitHubAdapter implements ForgeAdapter {
       repo,
       labels,
       state,
+      per_page: 100,
     });
 
     return data.map((issue) => ({

--- a/src/scanner/__tests__/finding-prioritizer-instances.test.ts
+++ b/src/scanner/__tests__/finding-prioritizer-instances.test.ts
@@ -1,0 +1,98 @@
+/**
+ * RFC-142: Tests for per-instance finding prioritization.
+ * prioritizeFindingInstances sorts individual Vulnerability objects
+ * (not VulnerabilityGroup) by CWE severity tier, then confidence.
+ */
+
+import { describe, it, expect } from 'vitest';
+import { prioritizeFindingInstances } from '../finding-prioritizer.js';
+import type { Vulnerability } from '../../security/types.js';
+import { VulnerabilityType } from '../../security/types.js';
+import type { SeverityTierMap } from '../finding-prioritizer.js';
+
+function makeFinding(overrides: Partial<Vulnerability> & { cweId: string; filePath: string }): Vulnerability {
+  return {
+    type: VulnerabilityType.XSS,
+    severity: 'high',
+    line: 1,
+    message: 'test',
+    description: 'test vuln',
+    confidence: 80,
+    ...overrides,
+  };
+}
+
+const tiers: SeverityTierMap = {
+  'CWE-89': 'critical',
+  'CWE-79': 'high',
+  'CWE-327': 'medium',
+  'CWE-798': 'low',
+};
+
+describe('prioritizeFindingInstances (RFC-142)', () => {
+  it('sorts findings by CWE severity tier (critical first)', () => {
+    const findings: Vulnerability[] = [
+      makeFinding({ cweId: 'CWE-327', filePath: 'crypto.js', severity: 'medium', confidence: 90 }),
+      makeFinding({ cweId: 'CWE-89', filePath: 'db.js', severity: 'critical', confidence: 80 }),
+      makeFinding({ cweId: 'CWE-79', filePath: 'page.js', severity: 'high', confidence: 85 }),
+    ];
+
+    const sorted = prioritizeFindingInstances(findings, tiers);
+
+    expect(sorted[0].cweId).toBe('CWE-89');  // critical
+    expect(sorted[1].cweId).toBe('CWE-79');  // high
+    expect(sorted[2].cweId).toBe('CWE-327'); // medium
+  });
+
+  it('sorts by confidence within the same tier', () => {
+    const findings: Vulnerability[] = [
+      makeFinding({ cweId: 'CWE-79', filePath: 'a.js', severity: 'high', confidence: 60 }),
+      makeFinding({ cweId: 'CWE-79', filePath: 'b.js', severity: 'high', confidence: 95 }),
+      makeFinding({ cweId: 'CWE-79', filePath: 'c.js', severity: 'high', confidence: 75 }),
+    ];
+
+    const sorted = prioritizeFindingInstances(findings, tiers);
+
+    expect(sorted[0].confidence).toBe(95);
+    expect(sorted[1].confidence).toBe(75);
+    expect(sorted[2].confidence).toBe(60);
+  });
+
+  it('does not mutate the input array', () => {
+    const findings: Vulnerability[] = [
+      makeFinding({ cweId: 'CWE-327', filePath: 'crypto.js', severity: 'medium', confidence: 90 }),
+      makeFinding({ cweId: 'CWE-89', filePath: 'db.js', severity: 'critical', confidence: 80 }),
+    ];
+
+    const original = [...findings];
+    prioritizeFindingInstances(findings, tiers);
+
+    expect(findings[0].cweId).toBe(original[0].cweId);
+    expect(findings[1].cweId).toBe(original[1].cweId);
+  });
+
+  it('falls back to pattern severity when CWE not in tier map', () => {
+    const findings: Vulnerability[] = [
+      makeFinding({ cweId: 'CWE-9999', filePath: 'a.js', severity: 'critical', confidence: 80 }),
+      makeFinding({ cweId: 'CWE-89', filePath: 'b.js', severity: 'critical', confidence: 80 }),
+    ];
+
+    const sorted = prioritizeFindingInstances(findings, tiers);
+
+    // Both are critical tier — CWE-89 via tier map, CWE-9999 via pattern fallback
+    // Same tier + same confidence = stable order
+    expect(sorted).toHaveLength(2);
+  });
+
+  it('handles empty array', () => {
+    const sorted = prioritizeFindingInstances([], tiers);
+    expect(sorted).toEqual([]);
+  });
+
+  it('handles single finding', () => {
+    const findings = [makeFinding({ cweId: 'CWE-79', filePath: 'x.js' })];
+    const sorted = prioritizeFindingInstances(findings, tiers);
+    expect(sorted).toHaveLength(1);
+    expect(sorted[0].cweId).toBe('CWE-79');
+  });
+});

--- a/src/scanner/__tests__/issue-creator-per-instance.test.ts
+++ b/src/scanner/__tests__/issue-creator-per-instance.test.ts
@@ -1,0 +1,345 @@
+/**
+ * RFC-142: Per-instance issue creation tests.
+ * TDD — RED phase: these tests define the contract for per-finding issue creation.
+ */
+
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { IssueCreator } from '../issue-creator.js';
+import type { ForgeAdapter, ForgeIssue } from '../../forge/forge-adapter.js';
+import type { ScanConfig } from '../types.js';
+import type { Vulnerability } from '../../security/types.js';
+import { VulnerabilityType } from '../../security/types.js';
+
+vi.mock('../../utils/logger.js', () => ({
+  logger: {
+    info: vi.fn(),
+    error: vi.fn(),
+    warn: vi.fn(),
+    debug: vi.fn()
+  }
+}));
+
+function createMockForgeAdapter(): {
+  [K in keyof ForgeAdapter]: ReturnType<typeof vi.fn>;
+} {
+  return {
+    listIssues: vi.fn().mockResolvedValue([]),
+    createIssue: vi.fn().mockImplementation(
+      (_owner: string, _repo: string, params: { title: string; body: string; labels: string[] }) =>
+        Promise.resolve({
+          number: Math.floor(Math.random() * 1000) + 1,
+          title: params.title,
+          url: `https://github.com/test/repo/issues/${Math.floor(Math.random() * 1000)}`,
+          labels: params.labels,
+          state: 'open'
+        } as ForgeIssue)
+    ),
+    updateIssue: vi.fn().mockResolvedValue(undefined),
+    addLabels: vi.fn().mockResolvedValue(undefined),
+    removeLabel: vi.fn().mockResolvedValue(undefined),
+    createComment: vi.fn().mockResolvedValue(undefined),
+    createPullRequest: vi.fn(),
+    listPullRequests: vi.fn(),
+    getFileTree: vi.fn(),
+    getFileContent: vi.fn(),
+  };
+}
+
+function makeFinding(overrides: Partial<Vulnerability> = {}): Vulnerability {
+  return {
+    type: VulnerabilityType.XSS,
+    severity: 'high',
+    line: 42,
+    message: 'Unescaped user input',
+    description: 'User input rendered without escaping',
+    confidence: 85,
+    cweId: 'CWE-79',
+    owaspCategory: 'A03:2021',
+    filePath: 'src/templates/admin.ejs',
+    snippet: 'innerHTML = userInput',
+    ...overrides,
+  };
+}
+
+const baseConfig: ScanConfig = {
+  repository: { owner: 'test', name: 'repo', defaultBranch: 'main' },
+  createIssues: true,
+};
+
+describe('IssueCreator - Per-Instance Issue Creation (RFC-142)', () => {
+  let issueCreator: IssueCreator;
+  let mockForge: ReturnType<typeof createMockForgeAdapter>;
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mockForge = createMockForgeAdapter();
+    issueCreator = new IssueCreator(mockForge as unknown as ForgeAdapter);
+  });
+
+  describe('createIssuesFromFindings', () => {
+    it('creates one issue per finding instance', async () => {
+      const findings: Vulnerability[] = [
+        makeFinding({ filePath: 'a.js', line: 10, cweId: 'CWE-79' }),
+        makeFinding({ filePath: 'b.js', line: 20, cweId: 'CWE-79' }),
+        makeFinding({ filePath: 'c.js', line: 30, cweId: 'CWE-89', type: VulnerabilityType.SQL_INJECTION }),
+      ];
+
+      const result = await issueCreator.createIssuesFromFindings(findings, baseConfig);
+
+      expect(result.issues).toHaveLength(3);
+      expect(mockForge.createIssue).toHaveBeenCalledTimes(3);
+    });
+
+    it('respects maxIssues cap on individual findings', async () => {
+      const findings: Vulnerability[] = [
+        makeFinding({ filePath: 'a.js', line: 10 }),
+        makeFinding({ filePath: 'b.js', line: 20 }),
+        makeFinding({ filePath: 'c.js', line: 30 }),
+        makeFinding({ filePath: 'd.js', line: 40 }),
+      ];
+
+      const result = await issueCreator.createIssuesFromFindings(
+        findings,
+        { ...baseConfig, maxIssues: 2 }
+      );
+
+      expect(result.issues).toHaveLength(2);
+      expect(mockForge.createIssue).toHaveBeenCalledTimes(2);
+    });
+
+    it('returns empty when createIssues is false', async () => {
+      const findings = [makeFinding()];
+      const result = await issueCreator.createIssuesFromFindings(
+        findings,
+        { ...baseConfig, createIssues: false }
+      );
+
+      expect(result.issues).toHaveLength(0);
+      expect(mockForge.createIssue).not.toHaveBeenCalled();
+    });
+
+    it('continues creating issues even if one fails', async () => {
+      let callCount = 0;
+      mockForge.createIssue.mockImplementation(
+        (_o: string, _r: string, params: { title: string; body: string; labels: string[] }) => {
+          callCount++;
+          if (callCount === 2) return Promise.reject(new Error('API Error'));
+          return Promise.resolve({
+            number: callCount,
+            title: params.title,
+            url: `https://github.com/test/repo/issues/${callCount}`,
+            labels: params.labels,
+            state: 'open'
+          } as ForgeIssue);
+        }
+      );
+
+      const findings = [
+        makeFinding({ filePath: 'a.js', line: 10 }),
+        makeFinding({ filePath: 'b.js', line: 20 }),
+        makeFinding({ filePath: 'c.js', line: 30 }),
+      ];
+
+      const result = await issueCreator.createIssuesFromFindings(findings, baseConfig);
+      expect(result.issues).toHaveLength(2); // 1st and 3rd succeed
+    });
+
+    it('populates filePath and line on CreatedIssue', async () => {
+      const findings = [makeFinding({ filePath: 'src/app.js', line: 77, cweId: 'CWE-89' })];
+
+      const result = await issueCreator.createIssuesFromFindings(findings, baseConfig);
+
+      expect(result.issues[0].filePath).toBe('src/app.js');
+      expect(result.issues[0].line).toBe(77);
+      expect(result.issues[0].cweId).toBe('CWE-89');
+    });
+
+    it('skips vendor findings', async () => {
+      const findings = [
+        makeFinding({ filePath: 'src/app.js', isVendor: false }),
+        makeFinding({ filePath: 'vendor/lib.js', isVendor: true }),
+      ];
+
+      const result = await issueCreator.createIssuesFromFindings(findings, baseConfig);
+
+      expect(result.issues).toHaveLength(1);
+      expect(result.issues[0].filePath).toBe('src/app.js');
+    });
+  });
+
+  describe('issue title format', () => {
+    it('uses [CWE-ID] Name in file:line format', async () => {
+      const findings = [makeFinding({
+        cweId: 'CWE-79',
+        filePath: 'src/templates/admin.ejs',
+        line: 42,
+      })];
+
+      await issueCreator.createIssuesFromFindings(findings, baseConfig);
+
+      const createCall = mockForge.createIssue.mock.calls[0];
+      const title = createCall[2].title;
+      expect(title).toBe('[CWE-79] Cross-Site Scripting (XSS) in src/templates/admin.ejs:42');
+    });
+
+    it('falls back to pattern type name when CWE unknown', async () => {
+      const findings = [makeFinding({
+        cweId: undefined,
+        type: VulnerabilityType.XSS,
+        filePath: 'page.js',
+        line: 10,
+      })];
+
+      await issueCreator.createIssuesFromFindings(findings, baseConfig);
+
+      const title = mockForge.createIssue.mock.calls[0][2].title;
+      expect(title).toMatch(/Cross-Site Scripting.*in page\.js:10/);
+    });
+  });
+
+  describe('issue body format', () => {
+    it('focuses on single finding instance', async () => {
+      const findings = [makeFinding({
+        cweId: 'CWE-79',
+        filePath: 'src/templates/admin.ejs',
+        line: 42,
+        description: 'User input rendered without escaping',
+        snippet: 'innerHTML = userInput',
+      })];
+
+      await issueCreator.createIssuesFromFindings(findings, baseConfig);
+
+      const body = mockForge.createIssue.mock.calls[0][2].body;
+      expect(body).toContain('src/templates/admin.ejs');
+      expect(body).toContain('Line 42');
+      expect(body).toContain('innerHTML = userInput');
+      // Should NOT contain "Total Instances" or "Affected Files" count
+      expect(body).not.toContain('Total Instances');
+    });
+  });
+
+  describe('labels', () => {
+    it('includes rsolv:cwe-XXX label for Phase 1.5 dedup', async () => {
+      const findings = [makeFinding({ cweId: 'CWE-79' })];
+
+      await issueCreator.createIssuesFromFindings(findings, baseConfig);
+
+      const labels: string[] = mockForge.createIssue.mock.calls[0][2].labels;
+      expect(labels).toContain('rsolv:cwe-CWE-79');
+      expect(labels).toContain('rsolv:detected');
+      expect(labels).toContain('security');
+    });
+
+    it('includes rsolv:vuln-TYPE label for backward compat', async () => {
+      const findings = [makeFinding({ type: VulnerabilityType.SQL_INJECTION, cweId: 'CWE-89' })];
+
+      await issueCreator.createIssuesFromFindings(findings, baseConfig);
+
+      const labels: string[] = mockForge.createIssue.mock.calls[0][2].labels;
+      expect(labels).toContain('rsolv:vuln-sql_injection');
+    });
+  });
+
+  describe('Phase 1.5: Temporal dedup by (cwe, file)', () => {
+    it('skips finding when open issue exists for same (cwe, file)', async () => {
+      // Simulate existing open issue for CWE-79 in admin.ejs
+      mockForge.listIssues.mockResolvedValue([{
+        number: 42,
+        title: '[CWE-79] Cross-Site Scripting (XSS) in src/templates/admin.ejs:42',
+        url: 'https://github.com/test/repo/issues/42',
+        labels: ['rsolv:detected', 'rsolv:cwe-CWE-79'],
+        state: 'open'
+      }]);
+
+      const findings = [makeFinding({
+        cweId: 'CWE-79',
+        filePath: 'src/templates/admin.ejs',
+        line: 42,
+      })];
+
+      const result = await issueCreator.createIssuesFromFindings(findings, baseConfig);
+
+      expect(result.issues).toHaveLength(0);
+      expect(result.skippedDuplicate).toBe(1); // temporal dedup
+      expect(result.skippedDismissed).toBe(0); // not dismissed, just deduped
+      expect(mockForge.createIssue).not.toHaveBeenCalled();
+    });
+
+    it('creates new issue when existing issue is for different file', async () => {
+      // Existing issue is for OTHER file with same CWE
+      mockForge.listIssues.mockResolvedValue([{
+        number: 42,
+        title: '[CWE-79] Cross-Site Scripting (XSS) in src/other.ejs:10',
+        url: 'https://github.com/test/repo/issues/42',
+        labels: ['rsolv:detected', 'rsolv:cwe-CWE-79'],
+        state: 'open'
+      }]);
+
+      const findings = [makeFinding({
+        cweId: 'CWE-79',
+        filePath: 'src/templates/admin.ejs',
+        line: 42,
+      })];
+
+      const result = await issueCreator.createIssuesFromFindings(findings, baseConfig);
+
+      expect(result.issues).toHaveLength(1);
+      expect(mockForge.createIssue).toHaveBeenCalledTimes(1);
+    });
+
+    it('matches by file path regardless of line number drift', async () => {
+      // Existing issue at line 42, new finding at line 45 in same file
+      mockForge.listIssues.mockResolvedValue([{
+        number: 42,
+        title: '[CWE-79] Cross-Site Scripting (XSS) in src/templates/admin.ejs:42',
+        url: 'https://github.com/test/repo/issues/42',
+        labels: ['rsolv:detected', 'rsolv:cwe-CWE-79'],
+        state: 'open'
+      }]);
+
+      const findings = [makeFinding({
+        cweId: 'CWE-79',
+        filePath: 'src/templates/admin.ejs',
+        line: 45, // line shifted
+      })];
+
+      const result = await issueCreator.createIssuesFromFindings(findings, baseConfig);
+
+      // Should still be deduped — same CWE + same file
+      expect(result.issues).toHaveLength(0);
+      expect(mockForge.createIssue).not.toHaveBeenCalled();
+    });
+
+    it('creates issue for same CWE when no open issue has matching file', async () => {
+      // No open issues at all
+      mockForge.listIssues.mockResolvedValue([]);
+
+      const findings = [makeFinding({ cweId: 'CWE-79', filePath: 'new-file.js' })];
+
+      const result = await issueCreator.createIssuesFromFindings(findings, baseConfig);
+
+      expect(result.issues).toHaveLength(1);
+    });
+
+    it('respects validated/false-positive/dismissed labels', async () => {
+      mockForge.listIssues.mockResolvedValue([{
+        number: 42,
+        title: '[CWE-79] Cross-Site Scripting (XSS) in src/templates/admin.ejs:42',
+        url: 'https://github.com/test/repo/issues/42',
+        labels: ['rsolv:validated', 'rsolv:cwe-CWE-79'],
+        state: 'open'
+      }]);
+
+      const findings = [makeFinding({
+        cweId: 'CWE-79',
+        filePath: 'src/templates/admin.ejs',
+        line: 42,
+      })];
+
+      const result = await issueCreator.createIssuesFromFindings(findings, baseConfig);
+
+      expect(result.issues).toHaveLength(0);
+      expect(result.skippedValidated).toBe(1);
+    });
+  });
+});

--- a/src/scanner/__tests__/issue-creator-per-instance.test.ts
+++ b/src/scanner/__tests__/issue-creator-per-instance.test.ts
@@ -20,8 +20,8 @@ vi.mock('../../utils/logger.js', () => ({
 }));
 
 function createMockForgeAdapter(): {
-  [K in keyof ForgeAdapter]: ReturnType<typeof vi.fn>;
-} {
+    [K in keyof ForgeAdapter]: ReturnType<typeof vi.fn>;
+    } {
   return {
     listIssues: vi.fn().mockResolvedValue([]),
     createIssue: vi.fn().mockImplementation(

--- a/src/scanner/__tests__/scan-orchestrator-max-issues.test.ts
+++ b/src/scanner/__tests__/scan-orchestrator-max-issues.test.ts
@@ -146,7 +146,7 @@ describe('ScanOrchestrator - max_issues bug', () => {
   });
 
   describe('GREEN - After the fix', () => {
-    it('should only pass limited groups to createIssuesFromGroups', async () => {
+    it('should only pass limited findings to createIssuesFromFindings (RFC-142)', async () => {
       const config: ScanConfig = {
         repository: {
           owner: 'test',
@@ -159,7 +159,7 @@ describe('ScanOrchestrator - max_issues bug', () => {
         excludePaths: []
       };
 
-      // Create 8 vulnerability groups
+      // Create 8 vulnerability groups (each with 1 finding)
       const groups: VulnerabilityGroup[] = Array.from({ length: 8 }, (_, i) => ({
         type: `vuln-type-${i}`,
         severity: 'high',
@@ -188,8 +188,8 @@ describe('ScanOrchestrator - max_issues bug', () => {
         }
       });
 
-      // Spy on createIssuesFromGroups to verify it's called with limited groups
-      const createIssuesSpy = vi.spyOn(orchestrator['issueCreator'], 'createIssuesFromGroups')
+      // RFC-142: Spy on createIssuesFromFindings (per-instance, not per-group)
+      const createIssuesSpy = vi.spyOn(orchestrator['issueCreator'], 'createIssuesFromFindings')
         .mockResolvedValue({
           issues: [
             { number: 1, title: 'Issue 1', url: 'url1', vulnerabilityType: 'vuln-type-0', fileCount: 1 },
@@ -201,14 +201,11 @@ describe('ScanOrchestrator - max_issues bug', () => {
 
       await orchestrator.performScan(config);
 
-      // After fix: createIssuesFromGroups should only get 2 groups
+      // RFC-142: createIssuesFromFindings receives ALL prioritized findings;
+      // max_issues cap is applied inside createIssuesFromFindings
       expect(createIssuesSpy).toHaveBeenCalledTimes(1);
-      const passedGroups = createIssuesSpy.mock.calls[0][0];
-      expect(passedGroups).toHaveLength(2); // Should only get 2 groups!
-
-      // Verify the first 2 groups were passed (not random ones)
-      expect(passedGroups[0].type).toBe('vuln-type-0');
-      expect(passedGroups[1].type).toBe('vuln-type-1');
+      const passedFindings = createIssuesSpy.mock.calls[0][0];
+      expect(passedFindings).toHaveLength(8); // All findings passed; capping is internal
     });
 
     it('should only create number of issues specified by max_issues', async () => {
@@ -309,7 +306,7 @@ describe('ScanOrchestrator - max_issues bug', () => {
       expect(result.createdIssues).toHaveLength(5);
     });
 
-    it('should prioritize by CWE severity tier before slicing by max_issues', async () => {
+    it('should prioritize findings by CWE severity tier (RFC-142)', async () => {
       const config: ScanConfig = {
         repository: {
           owner: 'test',
@@ -322,7 +319,7 @@ describe('ScanOrchestrator - max_issues bug', () => {
         excludePaths: []
       };
 
-      // Groups in insertion order: low-tier CWE first, critical-tier CWE last
+      // Findings in insertion order: low-tier CWE first, critical-tier CWE last
       const groups: VulnerabilityGroup[] = [
         {
           type: 'hardcoded_secrets',
@@ -387,7 +384,8 @@ describe('ScanOrchestrator - max_issues bug', () => {
         createdIssues: []
       });
 
-      const createIssuesSpy = vi.spyOn(orchestrator['issueCreator'], 'createIssuesFromGroups')
+      // RFC-142: spy on createIssuesFromFindings — receives prioritized individual findings
+      const createIssuesSpy = vi.spyOn(orchestrator['issueCreator'], 'createIssuesFromFindings')
         .mockResolvedValue({
           issues: [
             { number: 1, title: 'SQLi', url: 'url1', vulnerabilityType: 'sql_injection', fileCount: 1 },
@@ -399,14 +397,15 @@ describe('ScanOrchestrator - max_issues bug', () => {
 
       await orchestrator.performScan(config);
 
-      // With max_issues=2, prioritization should pick:
-      // 1. sql_injection (CWE-89 = Critical tier)
-      // 2. weak_cryptography (CWE-327 = Medium tier)
-      // NOT hardcoded_secrets (CWE-798 = Low tier) despite being first in insertion order
-      const passedGroups = createIssuesSpy.mock.calls[0][0];
-      expect(passedGroups).toHaveLength(2);
-      expect(passedGroups[0].type).toBe('sql_injection');
-      expect(passedGroups[1].type).toBe('weak_cryptography');
+      // Findings should be sorted by CWE severity tier:
+      // 1. sql_injection (CWE-89 = Critical)
+      // 2. weak_cryptography (CWE-327 = Medium)
+      // 3. hardcoded_secrets (CWE-798 = Low) — last despite insertion-first
+      const passedFindings = createIssuesSpy.mock.calls[0][0];
+      expect(passedFindings).toHaveLength(3);
+      expect(passedFindings[0].type).toBe('sql_injection');
+      expect(passedFindings[1].type).toBe('weak_cryptography');
+      expect(passedFindings[2].type).toBe('hardcoded_secrets');
     });
 
     it('should handle edge cases correctly', async () => {

--- a/src/scanner/__tests__/scan-output-orchestrator.test.ts
+++ b/src/scanner/__tests__/scan-output-orchestrator.test.ts
@@ -106,7 +106,7 @@ describe('ScanOrchestrator - scan_output (RFC-133 Phase 2)', () => {
         createdIssues: []
       });
 
-      const createIssuesSpy = vi.spyOn(orchestrator['issueCreator'], 'createIssuesFromGroups');
+      const createIssuesSpy = vi.spyOn(orchestrator['issueCreator'], 'createIssuesFromFindings');
 
       const result = await orchestrator.performScan(config);
 
@@ -132,7 +132,7 @@ describe('ScanOrchestrator - scan_output (RFC-133 Phase 2)', () => {
         createdIssues: []
       });
 
-      vi.spyOn(orchestrator['issueCreator'], 'createIssuesFromGroups')
+      vi.spyOn(orchestrator['issueCreator'], 'createIssuesFromFindings')
         .mockResolvedValue({
           issues: [
             { number: 1, title: 'Issue 1', url: 'url1', vulnerabilityType: 'vuln-type-0', fileCount: 1 },
@@ -162,7 +162,7 @@ describe('ScanOrchestrator - scan_output (RFC-133 Phase 2)', () => {
         createdIssues: []
       });
 
-      const createIssuesSpy = vi.spyOn(orchestrator['issueCreator'], 'createIssuesFromGroups');
+      const createIssuesSpy = vi.spyOn(orchestrator['issueCreator'], 'createIssuesFromFindings');
 
       const result = await orchestrator.performScan(config);
 
@@ -189,7 +189,7 @@ describe('ScanOrchestrator - scan_output (RFC-133 Phase 2)', () => {
         createdIssues: []
       });
 
-      vi.spyOn(orchestrator['issueCreator'], 'createIssuesFromGroups')
+      vi.spyOn(orchestrator['issueCreator'], 'createIssuesFromFindings')
         .mockResolvedValue({
           issues: [
             { number: 1, title: 'Issue 1', url: 'url1', vulnerabilityType: 'vuln-type-0', fileCount: 1 },
@@ -250,7 +250,7 @@ describe('ScanOrchestrator - scan_output (RFC-133 Phase 2)', () => {
         createdIssues: []
       });
 
-      vi.spyOn(orchestrator['issueCreator'], 'createIssuesFromGroups')
+      vi.spyOn(orchestrator['issueCreator'], 'createIssuesFromFindings')
         .mockResolvedValue({
           issues: [],
           skippedValidated: 0,
@@ -279,7 +279,7 @@ describe('ScanOrchestrator - scan_output (RFC-133 Phase 2)', () => {
         createdIssues: []
       });
 
-      vi.spyOn(orchestrator['issueCreator'], 'createIssuesFromGroups')
+      vi.spyOn(orchestrator['issueCreator'], 'createIssuesFromFindings')
         .mockResolvedValue({
           issues: [
             { number: 1, title: 'Issue 1', url: 'url1', vulnerabilityType: 'vuln-type-0', fileCount: 1 },

--- a/src/scanner/finding-prioritizer.ts
+++ b/src/scanner/finding-prioritizer.ts
@@ -1,5 +1,5 @@
 import type { VulnerabilityGroup } from './types.js';
-import type { Severity } from '../security/types.js';
+import type { Severity, Vulnerability } from '../security/types.js';
 import { SEVERITY_PRIORITY } from '../security/severity.js';
 import { logger } from '../utils/logger.js';
 
@@ -69,4 +69,34 @@ export function prioritizeFindings(groups: VulnerabilityGroup[], tiers: Severity
 
     return getMaxConfidence(b) - getMaxConfidence(a);
   });
+}
+
+/**
+ * RFC-142: Sort individual vulnerability instances by CWE severity tier,
+ * then by confidence (descending) within the same tier.
+ *
+ * Unlike prioritizeFindings (which operates on VulnerabilityGroup),
+ * this operates on flat Vulnerability[] for per-instance issue creation.
+ *
+ * @param findings - Individual vulnerability instances to sort
+ * @param tiers - CWE severity tier map from the platform
+ * @returns New sorted array — does not mutate the input.
+ */
+export function prioritizeFindingInstances(findings: Vulnerability[], tiers: SeverityTierMap): Vulnerability[] {
+  return [...findings].sort((a, b) => {
+    const tierA = SEVERITY_PRIORITY[getEffectiveFindingTier(a, tiers)];
+    const tierB = SEVERITY_PRIORITY[getEffectiveFindingTier(b, tiers)];
+
+    if (tierA !== tierB) return tierA - tierB;
+
+    return b.confidence - a.confidence;
+  });
+}
+
+/**
+ * Get the effective severity tier for a single finding.
+ * Uses CWE tier if available, falls back to pattern-level severity.
+ */
+function getEffectiveFindingTier(finding: Vulnerability, tiers: SeverityTierMap): Severity {
+  return getCweSeverityTier(finding.cweId, tiers) ?? finding.severity;
 }

--- a/src/scanner/issue-creator.ts
+++ b/src/scanner/issue-creator.ts
@@ -1,5 +1,6 @@
 import { logger } from '../utils/logger.js';
-import type { ForgeAdapter } from '../forge/forge-adapter.js';
+import type { ForgeAdapter, ForgeIssue } from '../forge/forge-adapter.js';
+import type { Vulnerability } from '../security/types.js';
 import type {
   VulnerabilityGroup,
   CreatedIssue,
@@ -259,6 +260,263 @@ export class IssueCreator {
     }
 
     return {issues: createdIssues, skippedValidated, skippedFalsePositive, skippedDismissed};
+  }
+
+  /**
+   * RFC-142: Create one GitHub issue per vulnerability finding instance.
+   * Replaces createIssuesFromGroups for per-instance granularity.
+   *
+   * Phase 1.5: Before creating, checks for existing open issue matching
+   * (cwe_id, file_path) to prevent temporal duplicates across re-scans.
+   */
+  async createIssuesFromFindings(
+    findings: Vulnerability[],
+    config: ScanConfig
+  ): Promise<IssueCreationResult> {
+    const createdIssues: CreatedIssue[] = [];
+    let skippedValidated = 0;
+    let skippedFalsePositive = 0;
+    let skippedDismissed = 0;
+    let skippedDuplicate = 0;
+
+    if (!config.createIssues) {
+      logger.info('Issue creation disabled, skipping');
+      return { issues: createdIssues, skippedValidated, skippedFalsePositive, skippedDismissed };
+    }
+
+    // Filter out vendor findings
+    const appFindings = findings.filter(f => !f.isVendor);
+    const vendorCount = findings.length - appFindings.length;
+
+    if (vendorCount > 0) {
+      logger.info(`Skipping ${vendorCount} vendor findings (require library updates, not code patches)`);
+    }
+
+    // Apply max_issues cap
+    const maxIssues = config.maxIssues;
+    const findingsToProcess = maxIssues ? appFindings.slice(0, maxIssues) : appFindings;
+
+    logger.info(`Processing ${findingsToProcess.length} individual findings` +
+                (maxIssues ? ` (limited by max_issues: ${maxIssues})` : ''));
+
+    if (maxIssues && appFindings.length > maxIssues) {
+      logger.info(`Note: ${appFindings.length - maxIssues} findings will be skipped due to max_issues limit`);
+    }
+
+    // Phase 1.5: Batch-fetch existing open issues with rsolv:detected label for dedup
+    let existingIssues: ForgeIssue[] = [];
+    try {
+      existingIssues = await this.forgeAdapter.listIssues(
+        config.repository.owner, config.repository.name, 'rsolv:detected', 'open'
+      );
+    } catch (error) {
+      logger.warn(`Failed to fetch existing issues for dedup: ${error}`);
+    }
+
+    for (const finding of findingsToProcess) {
+      try {
+        // Phase 1.5: Check for existing issue matching (cwe, file)
+        const existingMatch = this.findMatchingIssue(finding, existingIssues);
+
+        if (existingMatch) {
+          const labelNames = this.extractLabelNames(
+            existingMatch.labels.map(l => typeof l === 'string' ? { name: l } : l)
+          );
+          const skipStatus = this.checkSkipStatus(labelNames);
+
+          if (skipStatus === 'skip:validated') {
+            skippedValidated++;
+            logger.info(`Skipping validated finding: ${finding.cweId} in ${finding.filePath}`);
+            continue;
+          }
+          if (skipStatus === 'skip:false-positive') {
+            skippedFalsePositive++;
+            logger.info(`Skipping false positive finding: ${finding.cweId} in ${finding.filePath}`);
+            continue;
+          }
+          if (skipStatus === 'skip:dismissed') {
+            skippedDismissed++;
+            logger.info(`Skipping dismissed finding: ${finding.cweId} in ${finding.filePath}`);
+            continue;
+          }
+
+          // Existing rsolv:detected issue for same (cwe, file) — skip (temporal dedup)
+          skippedDuplicate++;
+          logger.info(`Skipping duplicate: issue #${existingMatch.number} already tracks ${finding.cweId} in ${finding.filePath}`);
+          continue;
+        }
+
+        // Create new issue for this finding instance
+        const issue = await this.createIssueForFinding(finding, config);
+        createdIssues.push(issue);
+        logger.info(`Created issue #${issue.number}: ${issue.title}`);
+      } catch (error) {
+        logger.error(`Failed to process finding ${finding.cweId} in ${finding.filePath}:`, error);
+      }
+    }
+
+    if (skippedDuplicate > 0) {
+      logger.info(`Skipped ${skippedDuplicate} findings with existing open issues (temporal dedup)`);
+    }
+
+    return { issues: createdIssues, skippedValidated, skippedFalsePositive, skippedDismissed, skippedDuplicate };
+  }
+
+  /**
+   * Phase 1.5: Find an existing open issue that matches (cwe_id, file_path).
+   * Matches by CWE label + file path in title. Line number is intentionally
+   * ignored (lines shift between scans).
+   */
+  private findMatchingIssue(finding: Vulnerability, existingIssues: ForgeIssue[]): ForgeIssue | null {
+    if (!finding.cweId || !finding.filePath) return null;
+
+    for (const issue of existingIssues) {
+      // Check CWE match via label
+      const hasCweLabel = issue.labels.some(l => {
+        const name = typeof l === 'string' ? l : (l as { name?: string }).name || '';
+        return name === `rsolv:cwe-${finding.cweId}`;
+      });
+
+      if (!hasCweLabel) continue;
+
+      // Check file path match in title (format: "[CWE-XX] Name in file/path:line")
+      const filePath = finding.filePath;
+      if (issue.title.includes(` in ${filePath}:`)) {
+        return issue;
+      }
+    }
+
+    return null;
+  }
+
+  /**
+   * RFC-142: Create a GitHub issue for a single finding instance.
+   */
+  private async createIssueForFinding(
+    finding: Vulnerability,
+    config: ScanConfig
+  ): Promise<CreatedIssue> {
+    const title = this.generateFindingTitle(finding);
+    const body = this.generateFindingBody(finding, config);
+
+    const labels = [
+      'rsolv:detected',
+      `rsolv:vuln-${finding.type}`,
+      'security',
+      finding.severity,
+      'automated-scan',
+    ];
+
+    // Phase 1.5: CWE-specific label for efficient dedup lookup
+    if (finding.cweId) {
+      labels.push(`rsolv:cwe-${finding.cweId}`);
+    }
+
+    if (process.env.RSOLV_DEMO_MODE === 'true' || process.env.RSOLV_AUTO_FIX === 'true') {
+      labels.push('rsolv:automate');
+      labels.push('demo');
+    }
+
+    const forgeIssue = await this.forgeAdapter.createIssue(
+      config.repository.owner, config.repository.name,
+      { title, body, labels }
+    );
+
+    return {
+      number: forgeIssue.number,
+      title: forgeIssue.title,
+      url: forgeIssue.url,
+      vulnerabilityType: finding.type,
+      fileCount: 1,
+      cweId: finding.cweId,
+      filePath: finding.filePath,
+      line: finding.line,
+    };
+  }
+
+  /**
+   * RFC-142: Issue title format: [CWE-79] Cross-Site Scripting (XSS) in src/file.js:42
+   */
+  private generateFindingTitle(finding: Vulnerability): string {
+    const readableType = getCweSpecificName(finding.cweId, finding.type);
+    const location = finding.filePath
+      ? `${finding.filePath}:${finding.line}`
+      : 'unknown location';
+
+    if (finding.cweId) {
+      return `[${finding.cweId}] ${readableType} in ${location}`;
+    }
+    return `${readableType} in ${location}`;
+  }
+
+  /**
+   * RFC-142: Issue body focused on single finding instance.
+   */
+  private generateFindingBody(finding: Vulnerability, config: ScanConfig): string {
+    const sections: string[] = [];
+    const readableType = getCweSpecificName(finding.cweId, finding.type);
+
+    sections.push('## Security Vulnerability Report');
+    sections.push('');
+    sections.push(`**Type**: ${readableType}`);
+    sections.push(`**Severity**: ${finding.severity.toUpperCase()}`);
+    if (finding.filePath) {
+      sections.push(`**File**: \`${finding.filePath}\``);
+    }
+    sections.push(`**Line ${finding.line}**`);
+    sections.push('');
+
+    // Security Classification
+    const classificationLines: string[] = [];
+    if (finding.cweId) {
+      const cweNum = finding.cweId.replace(/^CWE-/, '');
+      classificationLines.push(`- **CWE**: [${finding.cweId}](https://cwe.mitre.org/data/definitions/${cweNum}.html)`);
+    }
+    if (finding.owaspCategory) {
+      classificationLines.push(`- **OWASP**: ${formatOwaspLink(finding.owaspCategory)}`);
+    }
+    if (finding.confidence !== undefined) {
+      classificationLines.push(`- **Confidence**: ${finding.confidence}%`);
+    }
+    if (classificationLines.length > 0) {
+      sections.push('### Security Classification');
+      sections.push(...classificationLines);
+      sections.push('');
+    }
+
+    // Description
+    sections.push('### Description');
+    sections.push(finding.description || this.getVulnerabilityDescription(finding.type));
+    sections.push('');
+
+    // Code snippet
+    if (finding.snippet && finding.filePath) {
+      sections.push('### Vulnerable Code');
+      sections.push('');
+      const lang = this.detectLanguageFromPath(finding.filePath);
+      sections.push('```' + lang);
+      sections.push(`// ${finding.filePath}:${finding.line}`);
+      sections.push(finding.snippet.trim());
+      sections.push('```');
+      sections.push('');
+    }
+
+    // Recommendation
+    sections.push('### Recommendation');
+    sections.push(this.getVulnerabilityRecommendation(finding.type));
+    sections.push('');
+
+    // Footer
+    sections.push('---');
+    sections.push('*This issue was automatically generated by RSOLV security scanner*');
+    sections.push(`*Repository: ${config.repository.owner}/${config.repository.name}*`);
+    sections.push(`*Branch: ${config.repository.defaultBranch}*`);
+    sections.push(`*Scan Date: ${new Date().toISOString()}*`);
+    sections.push('');
+    sections.push('*To dismiss this finding, add one of these labels:*');
+    sections.push('*`rsolv:false-positive` \u00b7 `rsolv:wont-fix` \u00b7 `rsolv:accepted-risk` \u00b7 `rsolv:deferred`*');
+
+    return sections.join('\n');
   }
 
   private async findExistingIssue(

--- a/src/scanner/scan-orchestrator.ts
+++ b/src/scanner/scan-orchestrator.ts
@@ -4,7 +4,8 @@ import { GitHubAdapter } from '../forge/github-adapter.js';
 import { logger } from '../utils/logger.js';
 import { ensureLabelsExist } from '../github/label-manager.js';
 import type { ScanConfig, ScanResult, ScanReport, VulnerabilityGroup } from './types.js';
-import { prioritizeFindings, fetchSeverityTiers } from './finding-prioritizer.js';
+import type { Vulnerability } from '../security/types.js';
+import { prioritizeFindings, prioritizeFindingInstances, fetchSeverityTiers } from './finding-prioritizer.js';
 import type { SeverityTierMap } from './finding-prioritizer.js';
 
 export class ScanOrchestrator {
@@ -43,27 +44,27 @@ export class ScanOrchestrator {
       // RFC-133: Fetch tiers once — needed for both issue creation and report
       let tiers: SeverityTierMap | undefined;
       let prioritized: VulnerabilityGroup[] | undefined;
+      let prioritizedFindings: Vulnerability[] | undefined;
 
-      if (scanResult.groupedVulnerabilities.length > 0 && (shouldCreateIssues || shouldGenerateReport)) {
+      const hasVulnerabilities = scanResult.vulnerabilities.length > 0;
+
+      if (hasVulnerabilities && (shouldCreateIssues || shouldGenerateReport)) {
         tiers = await this.fetchTiers();
-        prioritized = prioritizeFindings(scanResult.groupedVulnerabilities, tiers);
+        // RFC-142: Prioritize individual findings for per-instance issue creation
+        prioritizedFindings = prioritizeFindingInstances(scanResult.vulnerabilities, tiers);
+        // Keep group-based prioritization for reports
+        if (scanResult.groupedVulnerabilities.length > 0) {
+          prioritized = prioritizeFindings(scanResult.groupedVulnerabilities, tiers);
+        }
       }
 
-      // Create issues if configured and vulnerabilities found
-      if (shouldCreateIssues && prioritized && prioritized.length > 0) {
-        const maxIssues = config.maxIssues;
-        const groupsToProcess = maxIssues ?
-          Math.min(maxIssues, prioritized.length) :
-          prioritized.length;
+      // RFC-142: Create one issue per finding instance (not per CWE group)
+      if (shouldCreateIssues && prioritizedFindings && prioritizedFindings.length > 0) {
+        logger.info(`RFC-142: Creating per-instance issues for ${prioritizedFindings.length} findings` +
+                    (config.maxIssues ? ` (max_issues: ${config.maxIssues})` : ''));
 
-        logger.info(`Creating issues for ${groupsToProcess} vulnerability groups` +
-                    (maxIssues && prioritized.length > maxIssues ?
-                      ` (limited by max_issues: ${maxIssues})` : ''));
-
-        const groupsToCreate = prioritized.slice(0, groupsToProcess);
-
-        const result = await this.issueCreator.createIssuesFromGroups(
-          groupsToCreate,
+        const result = await this.issueCreator.createIssuesFromFindings(
+          prioritizedFindings,
           { ...config, createIssues: true }
         );
 

--- a/src/scanner/types.ts
+++ b/src/scanner/types.ts
@@ -68,6 +68,10 @@ export interface CreatedIssue {
   vulnerabilityType: string;
   fileCount: number;
   cweId?: string;
+  /** RFC-142: file path for per-instance issues */
+  filePath?: string;
+  /** RFC-142: line number for per-instance issues */
+  line?: number;
 }
 
 export type IssueLabel = string | { name?: string };
@@ -86,6 +90,8 @@ export interface IssueCreationResult {
   skippedValidated: number;
   skippedFalsePositive: number;
   skippedDismissed?: number;
+  /** RFC-142 Phase 1.5: findings skipped because an open issue already tracks them */
+  skippedDuplicate?: number;
 }
 
 export interface FileToScan {


### PR DESCRIPTION
## Summary

- **Last marketplace blocker**: Replaces CWE-grouped issue creation with per-instance issues. Each vulnerability finding now produces its own GitHub issue with a focused title (`[CWE-79] XSS in file.js:42`), body, and labels.
- **Phase 1.5 temporal dedup**: Before creating an issue, checks for an existing open `rsolv:detected` issue matching the same `(cwe_id, file_path)` — prevents duplicates across re-scans without extra billing-side dedup logic.
- **GPT-5.4 reviewed**: Two issues caught and fixed — `skippedDuplicate` was tracked but dropped from return; `listIssues` pagination bumped from default 30 to 100.

### Changes

| File | Change |
|------|--------|
| `types.ts` | Added `filePath`, `line`, `skippedDuplicate` to `CreatedIssue`/`IssueCreationResult` |
| `finding-prioritizer.ts` | Added `prioritizeFindingInstances()` — sorts `Vulnerability[]` by CWE tier then confidence |
| `issue-creator.ts` | Added `createIssuesFromFindings()` with Phase 1.5 batch dedup, per-instance labels |
| `scan-orchestrator.ts` | Rewired to use per-instance path for issue creation, kept group path for reports |
| `github-adapter.ts` | `listIssues` pagination bumped to `per_page: 100` |
| New: `issue-creator-per-instance.test.ts` | 16 tests: creation, max_issues cap, vendor filter, dedup, labels |
| New: `finding-prioritizer-instances.test.ts` | 6 tests: tier sorting, confidence tiebreak, immutability |
| Updated: 2 existing orchestrator test files | Spy targets updated from `createIssuesFromGroups` → `createIssuesFromFindings` |

### Key decisions

- `max_issues=3` now means "3 individual findings" (was "3 CWE groups" which could be 3-15+ instances)
- Dedup ignores line numbers intentionally (they shift between scans)
- `createIssuesFromGroups` preserved alongside new path (still used by scan reports)

## Test plan

- [x] 156 scanner tests pass (+ 22 new)
- [x] TypeScript clean (`npx tsc --noEmit`)
- [x] Platform schema (`PipelineRunIssue`) is per-issue agnostic — no platform changes needed
- [x] GPT-5.4 Plan Reviewer review — 2 issues caught and fixed
- [ ] CI passes
- [ ] Staging smoke test against demo repo

**RFC**: [RFC-142](../RFCs/RFC-142-PER-INSTANCE-FINDING-GRANULARITY.md) — Status: Implemented (Phase 1 + 1.5)

🤖 Generated with [Claude Code](https://claude.com/claude-code)