### PR TITLE
feat: budget-aware scan planning (RFC-146 Phase 2)

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -67,6 +67,9 @@ inputs:
     description: 'Maximum number of issues to process in a single run'
     required: false
     default: '3'
+  max_validations:
+    description: 'Maximum validations to process per run. Capped by your remaining budget.'
+    required: false
   issue_number:
     description: 'Specific issue number to process (for workflow_dispatch)'
     required: false
@@ -121,6 +124,7 @@ runs:
     RSOLV_ENABLE_SECURITY_ANALYSIS: ${{ inputs.enable_security_analysis }}
     RSOLV_SCAN_OUTPUT: ${{ inputs.scan_output }}
     RSOLV_MAX_ISSUES: ${{ inputs.max_issues }}
+    RSOLV_MAX_VALIDATIONS: ${{ inputs.max_validations }}
     RSOLV_ISSUE_NUMBER: ${{ inputs.issue_number }}
     RSOLV_USE_GIT_BASED_EDITING: ${{ inputs.use_git_based_editing }}
     RSOLV_ENABLE_ENHANCED_CONTEXT: ${{ inputs.enable_enhanced_context }}

--- a/src/config/index.ts
+++ b/src/config/index.ts
@@ -67,6 +67,7 @@ const ActionConfigSchema = z.object({
   containerConfig: ContainerConfigSchema,
   securitySettings: SecuritySettingsSchema,
   maxIssues: z.number().min(1).optional(), // Maximum number of issues to process
+  maxValidations: z.number().min(1).optional(), // RFC-146: Maximum validations to process, capped by budget
   useGitBasedEditing: z.boolean().optional(), // Enable git-based in-place editing (ADR-012)
   useStructuredPhases: z.boolean().optional(), // Enable structured phased prompting (ADR-019)
   testGeneration: TestGenerationConfigSchema.optional(),
@@ -270,7 +271,15 @@ function loadConfigFromEnv(): Partial<ActionConfig> {
       envConfig.maxIssues = parsed;
     }
   }
-  
+
+  // RFC-146: Handle maxValidations separately to avoid NaN
+  if (process.env.RSOLV_MAX_VALIDATIONS) {
+    const parsed = parseInt(process.env.RSOLV_MAX_VALIDATIONS, 10);
+    if (!isNaN(parsed)) {
+      envConfig.maxValidations = parsed;
+    }
+  }
+
   // Handle useGitBasedEditing (ADR-012) - default to true
   if (process.env.RSOLV_USE_GIT_BASED_EDITING !== undefined) {
     envConfig.useGitBasedEditing = process.env.RSOLV_USE_GIT_BASED_EDITING === 'true';

--- a/src/index.ts
+++ b/src/index.ts
@@ -104,7 +104,8 @@ async function run(): Promise<ActionStatus> {
           // Job summary for scan results
           const createdIssues = (scanResult.createdIssues || []) as Array<{ number: number; title?: string; cwe_id?: string; vulnerabilityType?: string }>;
           const vulnCount = (scanResult.vulnerabilities as unknown[] || []).length;
-          writeScanSummary(repoFullName, createdIssues, vulnCount);
+          const scanPlan = (scanResult as Record<string, unknown>).scanPlan as import('./scanner/types.js').ScanPlanResponse | null | undefined;
+          writeScanSummary(repoFullName, createdIssues, vulnCount, scanPlan ?? null);
 
           // RFC-133: Write scan report files when scan_output includes 'report'
           if (scanResult.scanReport) {

--- a/src/modes/mode-selector.ts
+++ b/src/modes/mode-selector.ts
@@ -31,7 +31,11 @@ export class ModeSelector {
     const maxIssues = process.env.RSOLV_MAX_ISSUES
       ? parseInt(process.env.RSOLV_MAX_ISSUES, 10)
       : undefined;
-    
+
+    const maxValidations = process.env.RSOLV_MAX_VALIDATIONS
+      ? parseInt(process.env.RSOLV_MAX_VALIDATIONS, 10)
+      : undefined;
+
     const skipCache = process.env.RSOLV_SKIP_CACHE === 'true';
     
     // Validate configuration
@@ -42,14 +46,16 @@ export class ModeSelector {
       issueId,
       issueIds,
       maxIssues,
+      maxValidations,
       skipCache
     };
-    
+
     logger.info('Mode configuration:', {
       mode: config.mode,
       issueId: config.issueId,
       issueIds: config.issueIds,
       maxIssues: config.maxIssues,
+      maxValidations: config.maxValidations,
       skipCache: config.skipCache
     });
     

--- a/src/modes/phase-executor/index.ts
+++ b/src/modes/phase-executor/index.ts
@@ -206,7 +206,8 @@ export class PhaseExecutor {
         issueLabel: this.config.issueLabel || 'rsolv:automate',
         enableASTValidation: process.env.RSOLV_ENABLE_AST_VALIDATION !== 'false',
         rsolvApiKey: this.config.rsolvApiKey,
-        maxIssues: this.config.maxIssues
+        maxIssues: this.config.maxIssues,
+        maxValidations: this.config.maxValidations
       };
 
       if (this.config.scanOutput) {

--- a/src/modes/types.ts
+++ b/src/modes/types.ts
@@ -18,6 +18,7 @@ export interface ModeConfig {
   issueId?: number;  // Required for validate/mitigate/fix modes
   issueIds?: number[]; // For batch validation
   maxIssues?: number;  // Limit processing
+  maxValidations?: number; // RFC-146: Maximum validations to process, capped by budget
   skipCache?: boolean; // Bypass false positive cache
 }
 

--- a/src/scanner/__tests__/scan-orchestrator-max-issues.test.ts
+++ b/src/scanner/__tests__/scan-orchestrator-max-issues.test.ts
@@ -1,7 +1,33 @@
 import { describe, it, expect, beforeEach, vi } from 'vitest';
 import { ScanOrchestrator } from '../scan-orchestrator.js';
 import { logger } from '../../utils/logger.js';
-import type { ScanConfig, VulnerabilityGroup } from '../types.js';
+import type { ScanConfig, VulnerabilityGroup, ScanPlanFinding } from '../types.js';
+
+// Mock ScanPlanClient to pass all findings through (RFC-146 Phase 2)
+vi.mock('../scan-plan-client.js', () => ({
+  ScanPlanClient: class {
+    constructor() {}
+    async getPlan(request: { findings: ScanPlanFinding[]; max_issues: number; namespace: string }) {
+      // Default: return a plan that selects all findings (no budget constraint in tests)
+      return {
+        selected: request.findings,
+        deferred: [],
+        budget: {
+          tier: 'pro',
+          validate_limit: 100,
+          validate_used: 0,
+          validate_remaining: 100,
+          overage_cap_cents: 0,
+          overage_remaining_cents: 0,
+          max_validations: 100,
+          effective_cap: 100,
+          period_ends_at: null,
+          currency: 'usd',
+        },
+      };
+    }
+  },
+}));
 
 // Mock dependencies
 vi.mock('../../utils/logger.js', () => ({

--- a/src/scanner/__tests__/scan-plan-client.test.ts
+++ b/src/scanner/__tests__/scan-plan-client.test.ts
@@ -1,0 +1,123 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { ScanPlanClient } from '../scan-plan-client.js';
+import type { ScanPlanFinding, ScanPlanResponse } from '../types.js';
+
+const MOCK_FINDINGS: ScanPlanFinding[] = [
+  { cwe_id: 'CWE-89', severity: 'critical', file_path: 'src/db.ts', line: 42, type: 'sql_injection', confidence: 'high' },
+  { cwe_id: 'CWE-79', severity: 'high', file_path: 'src/view.ts', line: 18, type: 'xss', confidence: 'medium' },
+];
+
+const MOCK_RESPONSE: ScanPlanResponse = {
+  selected: [MOCK_FINDINGS[0]],
+  deferred: [{ ...MOCK_FINDINGS[1], reason: 'capacity_exceeded' }],
+  budget: {
+    tier: 'pro',
+    validate_limit: 25,
+    validate_used: 24,
+    validate_remaining: 1,
+    overage_cap_cents: 0,
+    overage_remaining_cents: 0,
+    max_validations: 1,
+    effective_cap: 1,
+    period_ends_at: '2026-05-01T00:00:00Z',
+    currency: 'usd',
+  },
+};
+
+describe('ScanPlanClient', () => {
+  let client: ScanPlanClient;
+
+  beforeEach(() => {
+    client = new ScanPlanClient({
+      apiUrl: 'https://api.rsolv.dev',
+      apiKey: 'test-key',
+    });
+    vi.restoreAllMocks();
+  });
+
+  it('returns plan on successful 200', async () => {
+    const fetchSpy = vi.spyOn(globalThis, 'fetch').mockResolvedValue(
+      new Response(JSON.stringify(MOCK_RESPONSE), { status: 200 })
+    );
+
+    const result = await client.getPlan({
+      findings: MOCK_FINDINGS,
+      max_issues: 3,
+      namespace: 'owner/repo',
+    });
+
+    expect(result).toEqual(MOCK_RESPONSE);
+    expect(fetchSpy).toHaveBeenCalledWith(
+      'https://api.rsolv.dev/api/v1/scan/plan',
+      expect.objectContaining({
+        method: 'POST',
+        headers: expect.objectContaining({
+          'Content-Type': 'application/json',
+          'x-api-key': 'test-key',
+        }),
+      })
+    );
+  });
+
+  it('returns null on transient 5xx failure', async () => {
+    vi.spyOn(globalThis, 'fetch').mockResolvedValue(
+      new Response('Internal Server Error', { status: 500 })
+    );
+
+    const result = await client.getPlan({
+      findings: MOCK_FINDINGS,
+      max_issues: 3,
+      namespace: 'owner/repo',
+    });
+
+    expect(result).toBeNull();
+  });
+
+  it('throws on hard 401 failure', async () => {
+    vi.spyOn(globalThis, 'fetch').mockResolvedValue(
+      new Response(JSON.stringify({ error: 'Unauthorized' }), { status: 401 })
+    );
+
+    await expect(
+      client.getPlan({ findings: MOCK_FINDINGS, max_issues: 3, namespace: 'owner/repo' })
+    ).rejects.toThrow('Scan plan request failed: 401');
+  });
+
+  it('throws on hard 403 failure', async () => {
+    vi.spyOn(globalThis, 'fetch').mockResolvedValue(
+      new Response(JSON.stringify({ error: 'Forbidden' }), { status: 403 })
+    );
+
+    await expect(
+      client.getPlan({ findings: MOCK_FINDINGS, max_issues: 3, namespace: 'owner/repo' })
+    ).rejects.toThrow('Scan plan request failed: 403');
+  });
+
+  it('returns null on network error', async () => {
+    vi.spyOn(globalThis, 'fetch').mockRejectedValue(new Error('Network unreachable'));
+
+    const result = await client.getPlan({
+      findings: MOCK_FINDINGS,
+      max_issues: 3,
+      namespace: 'owner/repo',
+    });
+
+    expect(result).toBeNull();
+  });
+
+  it('passes max_validations when provided', async () => {
+    const fetchSpy = vi.spyOn(globalThis, 'fetch').mockResolvedValue(
+      new Response(JSON.stringify(MOCK_RESPONSE), { status: 200 })
+    );
+
+    await client.getPlan({
+      findings: MOCK_FINDINGS,
+      max_issues: 3,
+      max_validations: 2,
+      namespace: 'owner/repo',
+    });
+
+    const body = JSON.parse(fetchSpy.mock.calls[0][1]?.body as string);
+    expect(body.max_validations).toBe(2);
+  });
+});

--- a/src/scanner/scan-orchestrator.ts
+++ b/src/scanner/scan-orchestrator.ts
@@ -4,9 +4,11 @@ import { GitHubAdapter } from '../forge/github-adapter.js';
 import { logger } from '../utils/logger.js';
 import { ensureLabelsExist } from '../github/label-manager.js';
 import type { ScanConfig, ScanResult, ScanReport, VulnerabilityGroup } from './types.js';
+import type { ScanPlanResponse, ScanPlanFinding } from './types.js';
 import type { Vulnerability } from '../security/types.js';
 import { prioritizeFindings, prioritizeFindingInstances, fetchSeverityTiers } from './finding-prioritizer.js';
 import type { SeverityTierMap } from './finding-prioritizer.js';
+import { ScanPlanClient } from './scan-plan-client.js';
 
 export class ScanOrchestrator {
   private scanner: RepositoryScanner;
@@ -58,13 +60,77 @@ export class ScanOrchestrator {
         }
       }
 
-      // RFC-142: Create one issue per finding instance (not per CWE group)
+      // RFC-146 Phase 2: Budget-aware scan planning + issue creation
+      let scanPlan: ScanPlanResponse | null = null;
+
       if (shouldCreateIssues && prioritizedFindings && prioritizedFindings.length > 0) {
-        logger.info(`RFC-142: Creating per-instance issues for ${prioritizedFindings.length} findings` +
-                    (config.maxIssues ? ` (max_issues: ${config.maxIssues})` : ''));
+        // Step 1: Query the platform for budget-aware plan
+        const apiUrl = process.env.RSOLV_API_URL || 'https://api.rsolv.dev';
+        const apiKey = process.env.RSOLV_API_KEY || '';
+
+        if (apiKey) {
+          const planClient = new ScanPlanClient({ apiUrl, apiKey });
+
+          const planFindings: ScanPlanFinding[] = prioritizedFindings.map(f => ({
+            cwe_id: f.cweId || 'CWE-unknown',
+            severity: f.severity,
+            file_path: f.filePath || 'unknown',
+            line: f.line,
+            type: f.type,
+            confidence: String(f.confidence || 'medium'),
+          }));
+
+          try {
+            scanPlan = await planClient.getPlan({
+              findings: planFindings,
+              max_issues: config.maxIssues || 3,
+              max_validations: config.maxValidations ?? undefined,
+              namespace: `${config.repository.owner}/${config.repository.name}`,
+            });
+
+            if (scanPlan) {
+              logger.info(
+                `[ScanPlan] Budget: ${scanPlan.budget.validate_used}/${scanPlan.budget.validate_limit} used, ` +
+                `effective cap: ${scanPlan.budget.effective_cap}, ` +
+                `selected: ${scanPlan.selected.length}, deferred: ${scanPlan.deferred.length}`
+              );
+            }
+          } catch (error) {
+            // Hard failure (401/403/400) — fail the job
+            logger.error(`[ScanPlan] Hard failure: ${error}`);
+            throw error;
+          }
+        }
+
+        // Step 2: Apply plan to select which findings to process
+        let findingsToProcess: Vulnerability[];
+        if (scanPlan) {
+          // Map selected findings back to original Vulnerability objects.
+          // Keys use the same fallbacks as planFindings construction above.
+          const selectedSet = new Set(
+            scanPlan.selected.map(f => `${f.cwe_id}:${f.file_path}:${f.line}`)
+          );
+          findingsToProcess = prioritizedFindings.filter(f =>
+            selectedSet.has(`${f.cweId || 'CWE-unknown'}:${f.filePath || 'unknown'}:${f.line}`)
+          );
+        } else {
+          // Fallback: conservative default (planning endpoint unavailable)
+          const fallbackCap = Math.min(
+            config.maxIssues || 3,
+            config.maxValidations ?? Infinity
+          );
+          findingsToProcess = prioritizedFindings.slice(0, fallbackCap);
+          logger.warn(`[ScanPlan] Using conservative fallback — processing ${findingsToProcess.length} findings`);
+        }
+
+        // Step 3: Create issues from selected findings
+        logger.info(
+          `RFC-142: Creating per-instance issues for ${findingsToProcess.length} findings` +
+          (config.maxIssues ? ` (max_issues: ${config.maxIssues})` : '')
+        );
 
         const result = await this.issueCreator.createIssuesFromFindings(
-          prioritizedFindings,
+          findingsToProcess,
           { ...config, createIssues: true }
         );
 
@@ -80,6 +146,9 @@ export class ScanOrchestrator {
           logger.info(`Skipped ${result.skippedFalsePositive} false positive issues`);
         }
       }
+
+      // Attach plan metadata for job summary (Task 10)
+      (scanResult as unknown as Record<string, unknown>).scanPlan = scanPlan;
 
       // RFC-133: Generate structured report (includes ALL findings, not capped)
       if (shouldGenerateReport && prioritized) {

--- a/src/scanner/scan-plan-client.ts
+++ b/src/scanner/scan-plan-client.ts
@@ -1,0 +1,60 @@
+import { logger } from '../utils/logger.js';
+import type { ScanPlanRequest, ScanPlanResponse } from './types.js';
+
+interface ScanPlanClientOptions {
+  apiUrl: string;
+  apiKey: string;
+}
+
+/**
+ * Client for POST /api/v1/scan/plan (RFC-146 Phase 2).
+ *
+ * Returns null on transient failures (5xx, timeout, network) — caller
+ * falls back to conservative default. Throws on hard failures (401, 403, 400)
+ * — these indicate misconfiguration.
+ */
+export class ScanPlanClient {
+  private apiUrl: string;
+  private apiKey: string;
+
+  constructor(options: ScanPlanClientOptions) {
+    this.apiUrl = options.apiUrl.replace(/\/$/, '');
+    this.apiKey = options.apiKey;
+  }
+
+  async getPlan(request: ScanPlanRequest): Promise<ScanPlanResponse | null> {
+    const url = `${this.apiUrl}/api/v1/scan/plan`;
+
+    try {
+      const response = await fetch(url, {
+        method: 'POST',
+        headers: {
+          'Content-Type': 'application/json',
+          'x-api-key': this.apiKey,
+        },
+        body: JSON.stringify(request),
+      });
+
+      if (response.ok) {
+        return (await response.json()) as ScanPlanResponse;
+      }
+
+      // Hard failures — misconfiguration, don't retry
+      if (response.status === 401 || response.status === 403 || response.status === 400) {
+        const body = await response.text();
+        throw new Error(`Scan plan request failed: ${response.status} — ${body}`);
+      }
+
+      // Transient failures — fall back to conservative default
+      logger.warn(`[ScanPlanClient] Transient failure: ${response.status}`);
+      return null;
+    } catch (error) {
+      // Network errors — fall back to conservative default
+      if (error instanceof Error && error.message.startsWith('Scan plan request failed')) {
+        throw error; // Re-throw hard failures
+      }
+      logger.warn(`[ScanPlanClient] Network error: ${error}`);
+      return null;
+    }
+  }
+}

--- a/src/scanner/types.ts
+++ b/src/scanner/types.ts
@@ -17,6 +17,7 @@ export interface ScanConfig {
   astValidationBatchSize?: number;
   rsolvApiKey?: string; // Needed for validation API
   maxIssues?: number; // Limit number of issues to create
+  maxValidations?: number; // RFC-146: Maximum validations to process, capped by budget
   scanDirectory?: string;
   excludePaths?: string[];
 }

--- a/src/scanner/types.ts
+++ b/src/scanner/types.ts
@@ -99,3 +99,44 @@ export interface FileToScan {
   content: string;
   language: string;
 }
+
+// RFC-146 Phase 2: Scan plan types
+
+export interface ScanPlanFinding {
+  cwe_id: string;
+  severity: string;
+  file_path: string;
+  line: number;
+  type: string;
+  confidence: string;
+}
+
+export interface ScanPlanDeferredFinding extends ScanPlanFinding {
+  reason: 'capacity_exceeded';
+}
+
+export interface ScanPlanBudget {
+  tier: string;
+  validate_limit: number;
+  validate_used: number;
+  validate_remaining: number;
+  overage_cap_cents: number;
+  overage_remaining_cents: number;
+  max_validations: number;
+  effective_cap: number;
+  period_ends_at: string | null;
+  currency: string;
+}
+
+export interface ScanPlanResponse {
+  selected: ScanPlanFinding[];
+  deferred: ScanPlanDeferredFinding[];
+  budget: ScanPlanBudget;
+}
+
+export interface ScanPlanRequest {
+  findings: ScanPlanFinding[];
+  max_issues: number;
+  max_validations?: number | null;
+  namespace: string;
+}

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -15,6 +15,7 @@ export interface ActionConfig {
   securitySettings: SecuritySettings;
   enableSecurityAnalysis?: boolean;
   maxIssues?: number; // Maximum number of issues to process in a single run
+  maxValidations?: number; // RFC-146: Maximum validations to process, capped by budget
   fixValidation?: FixValidationConfig;
   customerTier?: string;
   testGeneration?: TestGenerationConfig;

--- a/src/utils/__tests__/job-summary.test.ts
+++ b/src/utils/__tests__/job-summary.test.ts
@@ -164,3 +164,59 @@ describe('writeProcessSummary', () => {
     );
   });
 });
+
+describe('writeScanSummary with budget plan', () => {
+  const summaryFile = '/tmp/test-step-summary';
+
+  beforeEach(() => {
+    process.env.GITHUB_STEP_SUMMARY = summaryFile;
+    vi.mocked(appendFileSync).mockClear();
+  });
+
+  afterEach(() => {
+    delete process.env.GITHUB_STEP_SUMMARY;
+    vi.mocked(appendFileSync).mockClear();
+  });
+
+  it('renders budget info when scanPlan is provided', () => {
+    const plan = {
+      selected: [
+        { cwe_id: 'CWE-89', severity: 'critical', file_path: 'a.ts', line: 1, type: 'sqli', confidence: 'high' },
+      ],
+      deferred: [
+        { cwe_id: 'CWE-79', severity: 'high', file_path: 'b.ts', line: 2, type: 'xss', confidence: 'medium', reason: 'capacity_exceeded' as const },
+      ],
+      budget: {
+        tier: 'pro',
+        validate_limit: 25,
+        validate_used: 24,
+        validate_remaining: 1,
+        overage_cap_cents: 0,
+        overage_remaining_cents: 0,
+        max_validations: 1,
+        effective_cap: 1,
+        period_ends_at: '2026-05-01T00:00:00Z',
+        currency: 'usd',
+      },
+    };
+
+    writeScanSummary('owner/repo', [], 2, plan);
+
+    const written = vi.mocked(appendFileSync).mock.calls[0][1] as string;
+    expect(written).toContain('Budget');
+    expect(written).toContain('Pro plan');
+    expect(written).toContain('Processing');
+    expect(written).toContain('Deferred');
+    expect(written).toContain('CWE-89');
+    expect(written).toContain('CWE-79');
+  });
+
+  it('renders fallback message when scanPlan is null', () => {
+    writeScanSummary('owner/repo', [{ number: 1, cwe_id: 'CWE-89' }], 5, null);
+
+    const written = vi.mocked(appendFileSync).mock.calls[0][1] as string;
+    expect(written).toContain('Budget');
+    expect(written).toContain('unavailable');
+    expect(written).toContain('conservative default');
+  });
+});

--- a/src/utils/job-summary.ts
+++ b/src/utils/job-summary.ts
@@ -9,6 +9,7 @@
 
 import { appendFileSync } from 'fs';
 import { logger } from './logger.js';
+import type { ScanPlanResponse } from '../scanner/types.js';
 
 interface ScanIssue {
   number: number;
@@ -26,11 +27,13 @@ interface ProcessResult {
 
 /**
  * Write a job summary for a SCAN phase result.
+ * When a scan plan is available, includes budget info and selected/deferred breakdown.
  */
 export function writeScanSummary(
   repoFullName: string,
   createdIssues: ScanIssue[],
-  vulnerabilityCount: number
+  vulnerabilityCount: number,
+  scanPlan?: ScanPlanResponse | null
 ): void {
   const summaryFile = process.env.GITHUB_STEP_SUMMARY;
   if (!summaryFile) return;
@@ -40,10 +43,53 @@ export function writeScanSummary(
     '',
   ];
 
-  if (createdIssues.length === 0) {
+  if (vulnerabilityCount === 0) {
     lines.push('✅ No vulnerabilities detected.');
+  } else if (scanPlan) {
+    // Budget-aware summary
+    const budget = scanPlan.budget;
+    const tierLabel = capitalize(budget.tier);
+    const selectedCount = scanPlan.selected.length;
+    const deferredCount = scanPlan.deferred.length;
+
+    lines.push(`Found **${vulnerabilityCount}** potential vulnerabilities.`);
+    lines.push('');
+
+    // Budget line
+    const budgetParts: string[] = [`${budget.validate_used}/${budget.validate_limit} included used`];
+    if (budget.overage_cap_cents > 0) {
+      budgetParts.push(`$${budget.overage_cap_cents / 100} overage cap`);
+    }
+    lines.push(`**Budget:** ${budgetParts.join(' + ')} | ${tierLabel} plan`);
+    lines.push(`**Processing:** ${selectedCount} highest-severity findings`);
+    if (deferredCount > 0) {
+      lines.push(`**Deferred:** ${deferredCount} (will be picked up on next scan with available budget)`);
+    }
+
+    lines.push('');
+    lines.push('| # | Severity | CWE | File | Status |');
+    lines.push('|---|----------|-----|------|--------|');
+
+    // Selected findings
+    for (let i = 0; i < scanPlan.selected.length; i++) {
+      const f = scanPlan.selected[i];
+      lines.push(`| ${i + 1} | ${capitalize(f.severity)} | ${f.cwe_id} | \`${f.file_path}:${f.line}\` | ✅ Processing |`);
+    }
+
+    // Deferred findings
+    for (let i = 0; i < scanPlan.deferred.length; i++) {
+      const f = scanPlan.deferred[i];
+      const num = scanPlan.selected.length + i + 1;
+      lines.push(`| ${num} | ${capitalize(f.severity)} | ${f.cwe_id} | \`${f.file_path}:${f.line}\` | ⏳ Deferred |`);
+    }
+  } else if (createdIssues.length === 0) {
+    // No plan, no issues created
+    lines.push(`Found **${vulnerabilityCount}** potential vulnerabilities.`);
+    lines.push('**Budget:** information unavailable — using conservative default');
   } else {
+    // Fallback — no plan but issues were created
     lines.push(`Found **${vulnerabilityCount}** potential vulnerabilities. Created **${createdIssues.length}** issues for validation.`);
+    lines.push('**Budget:** information unavailable — using conservative default');
     lines.push('');
     lines.push('| Issue | Type |');
     lines.push('|-------|------|');
@@ -52,9 +98,6 @@ export function writeScanSummary(
       const cwe = issue.cwe_id || issue.vulnerabilityType || 'Unknown';
       lines.push(`| [#${issue.number}](../../issues/${issue.number}) | ${cwe} |`);
     }
-
-    lines.push('');
-    lines.push('Each issue will now be validated through behavioral testing.');
   }
 
   lines.push('');
@@ -67,6 +110,10 @@ export function writeScanSummary(
   } catch (error) {
     logger.warn('[JobSummary] Failed to write scan summary', error);
   }
+}
+
+function capitalize(s: string): string {
+  return s.charAt(0).toUpperCase() + s.slice(1);
 }
 
 interface IssueResult {


### PR DESCRIPTION
## Summary

- Add `ScanPlanClient` to call `POST /api/v1/scan/plan` for budget-aware finding selection before issue creation
- Wire 3-step scan flow: prioritize (RFC-142) → plan (RFC-146) → create issues, with graceful fallback when platform is unavailable
- Thread `max_validations` workflow input through action.yml → env → config → scan orchestrator
- Enhance job summary with budget info, selected/deferred findings table, and tier display

## Details

**RFC-146 Phase 2** — the Action side of budget-aware scan planning. The platform computes which findings to process based on the customer's validation budget; the Action is a thin client that sends prioritized findings and applies the plan's selection.

### ScanPlanClient (`src/scanner/scan-plan-client.ts`)
- Returns `null` on transient failures (5xx, timeout, network) — caller falls back to conservative default
- Throws on hard failures (401, 403, 400) — these indicate misconfiguration and should fail the job

### Scan Orchestrator Changes (`src/scanner/scan-orchestrator.ts`)
- After RFC-142 finding prioritization, queries the platform for a budget-aware plan
- Maps selected findings back to original `Vulnerability` objects using a `cweId:filePath:line` key set
- Fallback when no API key or plan unavailable: `slice(0, min(maxIssues, maxValidations))`

### Job Summary (`src/utils/job-summary.ts`)
- Budget-aware path: shows tier, usage (used/limit), overage cap, selected/deferred table with severity + CWE + file:line
- Fallback path: "Budget: information unavailable — using conservative default"

### `max_validations` Threading
- New `max_validations` input in `action.yml`
- Passed through `RSOLV_MAX_VALIDATIONS` env → config → ModeConfig → ScanConfig → orchestrator

## Test plan

- [ ] `npx tsc --noEmit` passes
- [ ] `npm run test:memory` passes
- [ ] Existing scan-orchestrator tests still pass
- [ ] Job summary renders correctly for budget-aware and fallback paths
- [ ] Platform PR (RSOLV-dev/rsolv#168) provides the endpoint this client calls

🤖 Generated with [Claude Code](https://claude.com/claude-code)