### PR TITLE
RFC-147: Three-Layer Noise Reduction + budget-awareness

### DIFF
--- a/README.md
+++ b/README.md
@@ -86,7 +86,7 @@ jobs:
 - One vulnerability per PR, no scope leak between fixes
 - `fail-fast: false` ensures one failure does not block other fixes
 - `max-parallel: 1` avoids branch conflicts (increase if your repo can handle concurrent PRs)
-- `max_issues: '3'` caps how many findings SCAN creates per run — controls your validation budget since only created issues enter the validate/fix pipeline
+- `max_issues: '3'` caps how many findings the SCAN step creates, which also limits how many issues the `process` job receives — adjust the `max_issues` value in the workflow YAML to fit your budget without changing the workflow logic
 
 **Scan Only** (Assessment mode)
 

--- a/README.md
+++ b/README.md
@@ -170,14 +170,23 @@ OWASP Top 10 coverage for JavaScript, TypeScript, Python, Ruby, Java, PHP, and E
 - **Vulnerable Components** — Outdated dependencies, dangerous functions
 - **SSRF** — Server-side request forgery with DNS rebinding protection
 
-### Two-Layer Validation
+### Three-Layer Noise Reduction
 
 **Layer 1: AST Analysis** filters the noise before you see it:
 - Comment detection (filters out documentation)
 - String literal analysis (ignores example code)
 - Data flow analysis (validates reachability)
 
-**Layer 2: Executable Proof** — every vulnerability that passes AST validation gets a generated exploit test. If the test can't prove the vulnerability, the issue is labeled inconclusive and no fix is attempted.
+**Layer 2: AI Defense Detection** — during validation, the AI identifies
+existing defenses: input sanitization, parameterized queries, framework-level
+protections. Findings with confirmed defenses are labeled false-positive
+and never generate a fix PR.
+
+**Layer 3: Executable Proof** — every remaining finding gets a generated
+test that exercises the actual code path. If the test can't prove the
+vulnerability, no fix is attempted.
+
+The result: only proven, exploitable vulnerabilities make it to your review queue.
 
 ## What You Get in a PR
 

--- a/README.md
+++ b/README.md
@@ -86,6 +86,7 @@ jobs:
 - One vulnerability per PR, no scope leak between fixes
 - `fail-fast: false` ensures one failure does not block other fixes
 - `max-parallel: 1` avoids branch conflicts (increase if your repo can handle concurrent PRs)
+- `max_issues: '3'` caps how many findings are validated per scan — control your validation budget without editing the workflow
 
 **Scan Only** (Assessment mode)
 

--- a/README.md
+++ b/README.md
@@ -86,7 +86,7 @@ jobs:
 - One vulnerability per PR, no scope leak between fixes
 - `fail-fast: false` ensures one failure does not block other fixes
 - `max-parallel: 1` avoids branch conflicts (increase if your repo can handle concurrent PRs)
-- `max_issues: '3'` caps how many findings are validated per scan — control your validation budget without editing the workflow
+- `max_issues: '3'` caps how many findings SCAN creates per run — controls your validation budget since only created issues enter the validate/fix pipeline
 
 **Scan Only** (Assessment mode)
 


### PR DESCRIPTION
## Summary

- **Three-Layer Noise Reduction**: Replaced "Two-Layer Validation" section with three layers: AST Analysis → AI Defense Detection → Executable Proof
- **Budget-awareness**: Added `max_issues` explanatory bullet to "Why this pattern?" section
- **Terminology**: Confirmed zero "overage" instances in README

## Copy Review

Section reviewed by GPT-5.4 and Claude:
- "Counter-Indication" → "Defense Detection" (clearer for marketplace audience)
- Closing line tightened: "only proven, exploitable vulnerabilities make it to your review queue"
- Heading "Three-Layer Noise Reduction" kept (avoids collision with VALIDATE phase)

## Test plan

- [ ] `grep "Three-Layer Noise Reduction" README.md` — heading present
- [ ] `grep "Two-Layer" README.md` — zero matches
- [ ] `grep "max_issues.*budget" README.md` — budget bullet present
- [ ] `grep -w overage README.md` — zero matches
- [ ] Verify marketplace listing renders at https://github.com/marketplace/actions/rsolv-test-first-ai-security-fixes after merge

🤖 Generated with [Claude Code](https://claude.com/claude-code)