### PR TITLE
chore(security): add gitleaks pre-commit + CI

### DIFF
--- a/.githooks/pre-commit
+++ b/.githooks/pre-commit
@@ -11,12 +11,18 @@
 
 set -e
 
+# Each `exec` branch dispatches the actual command directly with positional
+# args — avoids storing a multi-word command in a string and relying on
+# word-splitting (which would break if any path element contained spaces).
 if command -v gitleaks >/dev/null 2>&1; then
-  GITLEAKS_CMD="gitleaks"
-elif command -v mise >/dev/null 2>&1 && mise exec -- gitleaks version >/dev/null 2>&1; then
-  GITLEAKS_CMD="mise exec -- gitleaks"
-else
-  cat >&2 <<'EOF'
+  exec gitleaks protect --staged --no-banner --redact
+fi
+
+if command -v mise >/dev/null 2>&1 && mise exec -- gitleaks version >/dev/null 2>&1; then
+  exec mise exec -- gitleaks protect --staged --no-banner --redact
+fi
+
+cat >&2 <<'EOF'
 pre-commit: gitleaks not installed.
 
 Quick fix (preferred — installs the version pinned in .mise.toml):
@@ -27,7 +33,4 @@ Or install gitleaks another way (https://github.com/gitleaks/gitleaks#installing
 To bypass this check for a single commit (own the decision):
   git commit --no-verify
 EOF
-  exit 1
-fi
-
-exec $GITLEAKS_CMD protect --staged --no-banner --redact
+exit 1

--- a/.githooks/pre-commit
+++ b/.githooks/pre-commit
@@ -1,0 +1,33 @@
+#!/bin/sh
+# RSOLV-action pre-commit hook: scan staged changes for secrets via gitleaks.
+#
+# Auto-installed by mise's [hooks].enter when you cd into the repo with mise
+# active (see .mise.toml). The companion CI workflow at
+# .github/workflows/gitleaks.yml enforces the same scan server-side, so even
+# a commit that bypassed this hook with --no-verify will be caught at PR time.
+#
+# To intentionally skip this hook for a single commit (and own that decision):
+#   git commit --no-verify
+
+set -e
+
+if command -v gitleaks >/dev/null 2>&1; then
+  GITLEAKS_CMD="gitleaks"
+elif command -v mise >/dev/null 2>&1 && mise exec -- gitleaks version >/dev/null 2>&1; then
+  GITLEAKS_CMD="mise exec -- gitleaks"
+else
+  cat >&2 <<'EOF'
+pre-commit: gitleaks not installed.
+
+Quick fix (preferred — installs the version pinned in .mise.toml):
+  mise install
+
+Or install gitleaks another way (https://github.com/gitleaks/gitleaks#installing).
+
+To bypass this check for a single commit (own the decision):
+  git commit --no-verify
+EOF
+  exit 1
+fi
+
+exec $GITLEAKS_CMD protect --staged --no-banner --redact

--- a/.github/workflows/gitleaks.yml
+++ b/.github/workflows/gitleaks.yml
@@ -1,0 +1,64 @@
+name: gitleaks
+
+on:
+  pull_request:
+  push:
+    branches: [main]
+
+# We invoke the gitleaks BINARY directly rather than the gitleaks-action,
+# because gitleaks-action@v2 requires a paid licence for organisation repos.
+# The underlying gitleaks tool is MIT-licensed and free; only the GitHub
+# Action wrapper is paid. Keep GITLEAKS_VERSION in sync with .mise.toml.
+
+env:
+  GITLEAKS_VERSION: "8.30.1"
+
+jobs:
+  scan:
+    name: Secret Scan
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          # Full history so the diff range below has both endpoints available.
+          fetch-depth: 0
+
+      - name: Install gitleaks
+        run: |
+          set -euo pipefail
+          curl -fsSL "https://github.com/gitleaks/gitleaks/releases/download/v${GITLEAKS_VERSION}/gitleaks_${GITLEAKS_VERSION}_linux_x64.tar.gz" \
+            | sudo tar -xzC /usr/local/bin gitleaks
+          gitleaks version
+
+      # PR mode: scan only the new commits (PR diff against base). Avoids
+      # re-flagging historical leaks that were committed before this hook
+      # existed.
+      - name: Scan PR diff
+        if: github.event_name == 'pull_request'
+        env:
+          BASE_SHA: ${{ github.event.pull_request.base.sha }}
+          HEAD_SHA: ${{ github.event.pull_request.head.sha }}
+        run: |
+          gitleaks detect \
+            --no-banner \
+            --redact \
+            --log-opts="--no-merges $BASE_SHA..$HEAD_SHA"
+
+      # Push-to-main mode: scan only the new commits in this push.
+      - name: Scan push diff
+        if: github.event_name == 'push'
+        env:
+          BEFORE_SHA: ${{ github.event.before }}
+          AFTER_SHA: ${{ github.event.after }}
+        run: |
+          # On the very first push to main after this workflow lands,
+          # github.event.before is the all-zeros SHA; degrade to a no-op
+          # rather than scanning the entire history for that one event.
+          if [ "$BEFORE_SHA" = "0000000000000000000000000000000000000000" ]; then
+            echo "Initial push (no prior SHA). Skipping diff scan."
+            exit 0
+          fi
+          gitleaks detect \
+            --no-banner \
+            --redact \
+            --log-opts="--no-merges $BEFORE_SHA..$AFTER_SHA"

--- a/.github/workflows/gitleaks.yml
+++ b/.github/workflows/gitleaks.yml
@@ -26,8 +26,10 @@ jobs:
       - name: Install gitleaks
         run: |
           set -euo pipefail
+          # Explicit `-f -` so tar reads the archive from stdin rather than
+          # relying on the compiled-in default device fallback.
           curl -fsSL "https://github.com/gitleaks/gitleaks/releases/download/v${GITLEAKS_VERSION}/gitleaks_${GITLEAKS_VERSION}_linux_x64.tar.gz" \
-            | sudo tar -xzC /usr/local/bin gitleaks
+            | sudo tar -xzf - -C /usr/local/bin gitleaks
           gitleaks version
 
       # PR mode: scan only the new commits (PR diff against base). Avoids

--- a/.gitleaks.toml
+++ b/.gitleaks.toml
@@ -1,0 +1,35 @@
+title = "RSOLV-action gitleaks config"
+
+# Extend gitleaks' built-in rule set
+# (https://github.com/gitleaks/gitleaks/blob/master/config/gitleaks.toml).
+# We do NOT redefine rules — we just narrow when they fire via the allowlist
+# below. This keeps us up to date with upstream as new provider rules ship.
+[extend]
+useDefault = true
+
+# Repo-wide allowlist. Keep this list narrow: the goal is to suppress
+# documented false-positive PATTERNS (placeholder strings, generated output),
+# not entire categories of files. If you need to allow a specific real value,
+# prefer a `# gitleaks:allow` inline comment on the line itself.
+[allowlist]
+description = "RSOLV-action global allowlist"
+
+# Files that contain example/placeholder credentials only (never real ones).
+paths = [
+  '''.*\.env\.example$''',
+  # Compiled output of TS sources — original sources are scanned in-place.
+  '''^dist/.*''',
+]
+
+# Common placeholder/dummy strings used in docs and tests.
+regexes = [
+  '''YOUR_[A-Z_]+(_HERE)?''',
+  '''REPLACE_ME''',
+  '''<YOUR_[^>]*>''',
+  '''sk-ant-api03-xxx+''',
+  '''sk-test-[a-z_]+''',
+  '''dummy[-_]?[a-z]+[-_]?key''',
+  '''mock[-_]?[a-z]+[-_]?key''',
+  '''test[-_]?[a-z]+[-_]?key''',
+  '''xxxxxxxxx+''',
+]

--- a/.gitleaks.toml
+++ b/.gitleaks.toml
@@ -21,15 +21,18 @@ paths = [
   '''^dist/.*''',
 ]
 
-# Common placeholder/dummy strings used in docs and tests.
+# Common placeholder/dummy strings used in docs and tests. Patterns are
+# anchored with word boundaries (\b) so they match the placeholder *exactly*
+# rather than as a substring of an unrelated value — a real key that
+# happened to contain "REPLACE_ME" or "xxxxxxxxx" inside its random body
+# would otherwise be silently allowlisted.
 regexes = [
-  '''YOUR_[A-Z_]+(_HERE)?''',
-  '''REPLACE_ME''',
+  '''\bYOUR_[A-Z_]+(_HERE)?\b''',
+  '''\bREPLACE_ME\b''',
   '''<YOUR_[^>]*>''',
-  '''sk-ant-api03-xxx+''',
-  '''sk-test-[a-z_]+''',
-  '''dummy[-_]?[a-z]+[-_]?key''',
-  '''mock[-_]?[a-z]+[-_]?key''',
-  '''test[-_]?[a-z]+[-_]?key''',
-  '''xxxxxxxxx+''',
+  '''\bsk-ant-api03-x{20,}\b''',
+  '''\bsk-test-[a-z_]+\b''',
+  '''\bdummy[-_]?[a-z]+[-_]?key\b''',
+  '''\bmock[-_]?[a-z]+[-_]?key\b''',
+  '''\btest[-_]?[a-z]+[-_]?key\b''',
 ]

--- a/.mise.toml
+++ b/.mise.toml
@@ -1,0 +1,35 @@
+# Mise tool config for RSOLV-action.
+#
+# We keep .tool-versions around for asdf compatibility (nodejs, bun); this
+# file adds the bits asdf can't do — namely [hooks] for self-installing
+# git hooks and the gitleaks pinning.
+
+[tools]
+# Mirror .tool-versions
+node = "22.13.0"
+bun = "1.2.15"
+# Secret scanner. Pre-commit hook is in .githooks/ and self-installs via
+# the [hooks].enter block below. CI also enforces server-side via
+# .github/workflows/gitleaks.yml.
+gitleaks = "8.30.1"
+
+[hooks]
+enter = '''
+# Auto-install committed git hooks so contributors get secret-scanning on
+# every commit without a manual setup step. Idempotent — only writes when
+# core.hooksPath is not already pointed at the right place.
+#
+# Scope-gate: only act when the active git repo IS this repo (the one this
+# .mise.toml lives in). Without this check, cd-ing into a sibling repo
+# that lacks its own .mise.toml would re-fire this hook against that
+# repo and mis-set its core.hooksPath to a .githooks path that doesn't
+# exist there.
+toplevel=$(git rev-parse --show-toplevel 2>/dev/null || true)
+if [ -n "$toplevel" ] && [ "$toplevel" = "${MISE_PROJECT_ROOT:-}" ]; then
+  current_hooks_path=$(git config --local --get core.hooksPath 2>/dev/null || true)
+  if [ "$current_hooks_path" != ".githooks" ]; then
+    git config --local core.hooksPath .githooks
+    echo "✓ git core.hooksPath set to .githooks (gitleaks pre-commit enabled)"
+  fi
+fi
+'''


### PR DESCRIPTION
## Summary

Mirrors rsolv-platform#187 (already merged). Adds secret-scanning via gitleaks to prevent the class of mistake that caused the 2026-04 platform-side incident — a real Anthropic API key pasted inline into a markdown status report which then sat in private-repo history until a third party started using the key.

**Components:**
- `.mise.toml` — new file (alongside existing `.tool-versions` for asdf compat). Pins `gitleaks 8.30.1` and adds `[hooks].enter` to set `core.hooksPath = .githooks` (scope-gated so it doesn't fire when cd-ing into sibling repos).
- `.githooks/pre-commit` — runs `gitleaks protect --staged`. Falls back through PATH → `mise exec`. Useful failure message + `--no-verify` bypass info if gitleaks is missing.
- `.gitleaks.toml` — extends upstream's rule set; narrow allowlist for `dist/` (compiled TS output) and obvious placeholder strings.
- `.github/workflows/gitleaks.yml` — direct binary invocation (the gitleaks-action wrapper requires a paid licence for organisation repos).

## Test plan

- [x] `mise install` picks up gitleaks 8.30.1 in this repo
- [x] `mise exec -- gitleaks protect --staged --no-banner --redact` → no leaks
- [x] `mise exec -- gitleaks detect --log-opts="--no-merges main..HEAD"` → no leaks
- [ ] CI's gitleaks job runs on this PR (validates the workflow itself)

🤖 Generated with [Claude Code](https://claude.com/claude-code)