### PR TITLE
chore: scope Dependabot to root package.json (skip test fixtures)

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,24 @@
+# Dependabot configuration for RSOLV-action.
+#
+# Scopes Dependabot strictly to the root `package.json` so the updater
+# does not try to manage `test-fixtures/claude-code/sample-repo/package.json`
+# (and similar fixture manifests) — those are intentionally minimal/legacy
+# and don't ship; security advisories against them are noise.
+#
+# Without this config Dependabot uses GitHub defaults, which auto-discover
+# every `package.json` in the repo. That surfaced today as a failed
+# "Dependabot Updates" run trying to apply a mongoose security patch to
+# the fixture, which the updater container couldn't process.
+
+version: 2
+updates:
+  - package-ecosystem: "npm"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+    open-pull-requests-limit: 10
+
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      interval: "weekly"


### PR DESCRIPTION
## Summary

Adds a minimal `.github/dependabot.yml` so Dependabot only manages the root `package.json` (plus GitHub Actions versions).

## Why

Without this config, Dependabot uses GitHub defaults — which auto-discover **every** `package.json` in the repo. That surfaced today as a failed \"Dependabot Updates\" main-CI run (see https://github.com/RSOLV-dev/rsolv-action/actions/runs/24966654973): Dependabot tried to apply a mongoose security patch inside `test-fixtures/claude-code/sample-repo/package.json`. That fixture is intentionally minimal/legacy for tests and doesn't ship to production; its package.json is shaped oddly enough that the Dependabot updater container couldn't process it.

Net result: a recurring failed-run in main CI for a security patch that doesn't matter.

## What changes for users

- Dependabot will no longer attempt to manage / open security PRs against `test-fixtures/**/package.json` files
- `github-actions` ecosystem is now explicitly enabled (was implicit / inconsistent)
- `open-pull-requests-limit: 10` — gives some headroom but caps runaway PR generation

## Test plan

- [x] YAML syntax valid (Dependabot will reject malformed config in its own scheduled run)
- [ ] Watch next \"Dependabot Updates\" run for the mongoose-on-fixture noise to stop

🤖 Generated with [Claude Code](https://claude.com/claude-code)