### PR TITLE
fix: wire github-token input to env, drop dead claude_max_turns

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -98,10 +98,6 @@ inputs:
     description: 'RFC-060: Enable executable test generation in VALIDATE phase'
     required: false
     default: 'true'
-  claude_max_turns:
-    description: 'DEPRECATED: Turn limit is now controlled server-side (50 turns). This input is parsed but not used in mode=process (the canonical workflow).'
-    required: false
-    default: '50'
   create_pr:
     description: 'Create Pull Request after successful mitigation (default: true for production)'
     required: false
@@ -132,9 +128,9 @@ runs:
     RSOLV_USE_STRUCTURED_PHASES: ${{ inputs.use_structured_phases }}
     RSOLV_EDUCATIONAL_PR: ${{ inputs.enable_educational_pr }}
     RSOLV_EXECUTABLE_TESTS: ${{ inputs.executable_tests }}
-    RSOLV_CLAUDE_MAX_TURNS: ${{ inputs.claude_max_turns }}
     RSOLV_CREATE_PR: ${{ inputs.create_pr }}
     RSOLV_PIPELINE_RUN_ID: ${{ inputs.pipeline_run_id }}
+    GITHUB_TOKEN: ${{ inputs['github-token'] }}
 outputs:
   has_issues:
     description: 'Whether issues were found for processing'

--- a/docs/NOT-VALIDATED-RUNBOOK.md
+++ b/docs/NOT-VALIDATED-RUNBOOK.md
@@ -112,9 +112,9 @@ Issue tagged "not-validated"
 ├─ Were tests generated? (Check validation branch)
 │  │
 │  ├─ NO → [TEST GENERATION FAILURE]
-│  │      ├─ Check Claude Code SDK logs
-│  │      ├─ Check retry count (default: 5)
-│  │      └─ Resolution: Retry with higher claude_max_turns
+│  │      ├─ Check platform orchestrator logs (RFC-096)
+│  │      ├─ Check turn count vs server-side cap (50)
+│  │      └─ Resolution: Manual test refinement or platform escalation
 │  │
 │  └─ YES → Continue to next step
 │
@@ -220,29 +220,20 @@ git push
 
 ### Procedure 2: Test Generation Failure Resolution
 
-**When to Use**: No tests were generated (Claude Code SDK failed)
+**When to Use**: No tests were generated (platform orchestrator failed)
 
 **Steps**:
 
-1. **Check Retry Count**:
+1. **Check Turn Count in Platform Logs**:
 ```bash
-# Review workflow logs
-gh run view <RUN_ID> --log | grep "claude_max_turns"
-
-# Typical output: "Using claude_max_turns: 5"
+# Review action workflow logs for backend tool-loop turns
+gh run view <RUN_ID> --log | grep -E 'turn[s]?|tool_use'
 ```
+The platform-side turn cap is fixed at 50 (RFC-096) and not workflow-tunable.
 
-2. **Increase Retry Limit and Re-run**:
+2. **Re-run the Workflow** (transient platform failures usually self-heal):
 ```bash
-# Trigger workflow with higher retry limit
-gh workflow run "RSOLV AutoFix" \
-  -f issue_number=<ISSUE_NUMBER> \
-  -f claude_max_turns=10
-
-# Or edit workflow file
-# .github/workflows/rsolv-autofix.yml:
-# with:
-#   claude_max_turns: 10  # Increased from 5
+gh workflow run "RSOLV AutoFix" -f issue_number=<ISSUE_NUMBER>
 ```
 
 3. **If Still Failing, Manual Test Creation**:
@@ -511,7 +502,7 @@ See debug tarball: [link to upload]
 **Timeframe**: 24-72 hours
 
 **Escalation Criteria**:
-- Test generation fails after retry with `claude_max_turns=10`
+- Test generation fails after a clean re-run of the workflow
 - Test validation failure in complex codebase (requires deep code review)
 - Recurring pattern of failures in specific file/module
 

--- a/docs/VALIDATION-TROUBLESHOOTING.md
+++ b/docs/VALIDATION-TROUBLESHOOTING.md
@@ -397,12 +397,16 @@ kubectl logs -n rsolv-production -l app=rsolv-api --tail=100
 - Check if issue is particularly complex (large file, many vulnerabilities)
 
 **Resolution**:
-1. **Increase job-level timeout**:
+1. **Increase job-level timeout** (set on the job, not the step):
 ```yaml
-- uses: RSOLV-dev/rsolv-action@v4
-  with:
-    rsolvApiKey: ${{ secrets.RSOLV_API_KEY }}
-  timeout-minutes: 30  # Job-level timeout
+jobs:
+  rsolv:
+    runs-on: ubuntu-latest
+    timeout-minutes: 30  # Job-level timeout
+    steps:
+      - uses: RSOLV-dev/rsolv-action@v4
+        with:
+          rsolvApiKey: ${{ secrets.RSOLV_API_KEY }}
 ```
 
 2. **Simplify issue**: Break large issues into smaller chunks

--- a/docs/VALIDATION-TROUBLESHOOTING.md
+++ b/docs/VALIDATION-TROUBLESHOOTING.md
@@ -81,19 +81,19 @@ cat .rsolv/validation/issue-<number>.json
 
 **Resolution Strategies**:
 
-1. **Increase retry limit**: Add `claude_max_turns: 10` to workflow config
-2. **Manual test refinement**: Edit tests to properly detect vulnerability
-3. **Check vulnerability legitimacy**: Verify with manual code review
-4. **Framework detection override**: Specify framework explicitly in config
+1. **Manual test refinement**: Edit tests to properly detect vulnerability
+2. **Check vulnerability legitimacy**: Verify with manual code review
+3. **Framework detection override**: Specify framework explicitly in config
+
+> Turn limit is fixed at 50 server-side (RFC-096). It is not configurable from the workflow.
 
 **Example Fix**:
 ```yaml
-- uses: RSOLV-dev/rsolv-action@v2
+- uses: RSOLV-dev/rsolv-action@v4
   with:
-    api_key: ${{ secrets.RSOLV_API_KEY }}
+    rsolvApiKey: ${{ secrets.RSOLV_API_KEY }}
     mode: validate
     issue_number: ${{ github.event.issue.number }}
-    claude_max_turns: 10  # Increased from 5
     test_framework: rspec  # Override detection
 ```
 
@@ -397,18 +397,17 @@ kubectl logs -n rsolv-production -l app=rsolv-api --tail=100
 - Check if issue is particularly complex (large file, many vulnerabilities)
 
 **Resolution**:
-1. **Increase timeout** (if workflow allows):
+1. **Increase job-level timeout**:
 ```yaml
-- uses: RSOLV-dev/rsolv-action@v2
+- uses: RSOLV-dev/rsolv-action@v4
   with:
-    api_key: ${{ secrets.RSOLV_API_KEY }}
-    claude_max_turns: 10  # More iterations = longer timeout needed
+    rsolvApiKey: ${{ secrets.RSOLV_API_KEY }}
   timeout-minutes: 30  # Job-level timeout
 ```
 
 2. **Simplify issue**: Break large issues into smaller chunks
-3. **Reduce context**: Limit file size sent to Claude Code
-4. **Check Claude Code API status**: May be experiencing rate limits
+3. **Reduce context**: Limit file size sent to backend
+4. **Check platform status**: May be experiencing rate limits or capacity pressure
 
 ### Symptom: Tests Don't Detect Vulnerability
 

--- a/src/__tests__/action-yml-contract.test.ts
+++ b/src/__tests__/action-yml-contract.test.ts
@@ -1,0 +1,43 @@
+import { describe, expect, test } from 'vitest';
+import { readFileSync } from 'node:fs';
+import { join } from 'node:path';
+import yaml from 'js-yaml';
+
+// Contract tests for action.yml — the action's public surface.
+// Why: inputs declared without env-block wiring become phantom controls
+// (declared, accepted, never propagated to the container). See
+// memory/feedback_phantom_input_inert.md for the latent-bug pattern.
+
+interface ActionManifest {
+  inputs?: Record<string, { description?: string; required?: boolean; default?: string }>;
+  runs?: { env?: Record<string, string> };
+}
+
+function loadActionManifest(): ActionManifest {
+  const path = join(__dirname, '..', '..', 'action.yml');
+  return yaml.load(readFileSync(path, 'utf8')) as ActionManifest;
+}
+
+describe('action.yml contract', () => {
+  describe('GITHUB_TOKEN propagation', () => {
+    test('runs.env maps GITHUB_TOKEN from inputs.github-token', () => {
+      const manifest = loadActionManifest();
+      const env = manifest.runs?.env ?? {};
+      expect(env.GITHUB_TOKEN).toBeDefined();
+      // Bracket form is required because `inputs.github-token` parses as subtraction.
+      expect(env.GITHUB_TOKEN).toMatch(/inputs\['github-token'\]/);
+    });
+  });
+
+  describe('claude_max_turns removal', () => {
+    test('input is no longer declared (deprecated, server-side controlled)', () => {
+      const manifest = loadActionManifest();
+      expect(manifest.inputs?.claude_max_turns).toBeUndefined();
+    });
+
+    test('runs.env no longer wires RSOLV_CLAUDE_MAX_TURNS', () => {
+      const manifest = loadActionManifest();
+      expect(manifest.runs?.env?.RSOLV_CLAUDE_MAX_TURNS).toBeUndefined();
+    });
+  });
+});

--- a/src/__tests__/action-yml-contract.test.ts
+++ b/src/__tests__/action-yml-contract.test.ts
@@ -1,12 +1,15 @@
 import { describe, expect, test } from 'vitest';
 import { readFileSync } from 'node:fs';
-import { join } from 'node:path';
+import { dirname, join } from 'node:path';
+import { fileURLToPath } from 'node:url';
 import yaml from 'js-yaml';
 
 // Contract tests for action.yml — the action's public surface.
 // Why: inputs declared without env-block wiring become phantom controls
 // (declared, accepted, never propagated to the container). See
 // memory/feedback_phantom_input_inert.md for the latent-bug pattern.
+
+const __dirname = dirname(fileURLToPath(import.meta.url));
 
 interface ActionManifest {
   inputs?: Record<string, { description?: string; required?: boolean; default?: string }>;

--- a/src/config/index.ts
+++ b/src/config/index.ts
@@ -73,7 +73,6 @@ const ActionConfigSchema = z.object({
   testGeneration: TestGenerationConfigSchema.optional(),
   fixValidation: FixValidationConfigSchema.optional(),
   executableTests: z.boolean().optional(), // RFC-060 Phase 5.1: Enable executable test flow
-  claudeMaxTurns: z.number().min(1).max(20).optional(), // RFC-060 Phase 5.1: Maximum Claude iterations (1-20)
   createPR: z.boolean().optional(), // Create Pull Request after successful mitigation (default: true)
   scanOutput: z.array(z.string()).optional() // RFC-133: where scan findings go
 });
@@ -204,7 +203,6 @@ function getDefaultConfig(): Partial<ActionConfig> {
     },
     // RFC-060 Phase 5.1: Executable test generation (enabled by default)
     executableTests: process.env.RSOLV_EXECUTABLE_TESTS !== 'false', // Default true
-    claudeMaxTurns: 5, // Default to 5 turns for Claude iterations
     createPR: true // Default to true - customers expect PRs after mitigation
   };
 }
@@ -297,16 +295,6 @@ function loadConfigFromEnv(): Partial<ActionConfig> {
   // RFC-060 Phase 5.1: Handle executableTests feature flag
   if (process.env.RSOLV_EXECUTABLE_TESTS !== undefined) {
     envConfig.executableTests = process.env.RSOLV_EXECUTABLE_TESTS === 'true';
-  }
-
-  // RFC-060 Phase 5.1: Handle claudeMaxTurns configuration
-  if (process.env.RSOLV_CLAUDE_MAX_TURNS) {
-    const parsed = parseInt(process.env.RSOLV_CLAUDE_MAX_TURNS, 10);
-    if (!isNaN(parsed) && parsed >= 1 && parsed <= 20) {
-      envConfig.claudeMaxTurns = parsed;
-    } else {
-      logger.warn(`Invalid RSOLV_CLAUDE_MAX_TURNS value: ${process.env.RSOLV_CLAUDE_MAX_TURNS}. Must be between 1 and 20. Using default: 5`);
-    }
   }
 
   // Handle createPR configuration (default: true)

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -23,7 +23,6 @@ export interface ActionConfig {
   useStructuredPhases?: boolean; // Enable structured phased prompting for Claude Code
   claudeCodeConfig?: any; // Claude Code specific configuration
   executableTests?: boolean; // RFC-060 Phase 5.1: Enable executable test flow (RSOLV_EXECUTABLE_TESTS)
-  claudeMaxTurns?: number; // RFC-060 Phase 5.1: Maximum Claude iterations for test generation (default: 5)
   createPR?: boolean; // Create Pull Request after successful mitigation (default: true)
   scanOutput?: string[]; // RFC-133: where scan findings go ('issues', 'report', 'dashboard')
 }


### PR DESCRIPTION
## Summary

Two related fixes triggered by alpha user Jason Allen's run on 2026-04-29 (used `with: github-token: ${{ secrets.GITHUB_TOKEN }}` and saw `No GitHub token found` plus a misleading `claude_max_turns must be 1-20, using default 5` warning).

### github-token was a phantom input

`action.yml` declared `github-token` as an input (with `default: ${{ github.token }}`) but never wired it through `runs.env:` — commit 0dc2033c (May 2025) removed `GITHUB_TOKEN: ${{ github.token }}` from that block and never restored it. The fallback in `entrypoint.sh` that probes `printenv 'INPUT_GITHUB-TOKEN'` is unreliable for hyphenated input names across the runner→Docker→shell layers.

Users who copied the README's canonical step-level pattern (`env: GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}`) succeeded — masking the bug. Users who used the documented input failed silently. **Latent bug, not a regression** — same broken plumbing existed in v3 (`rad/tags/v3 = af1a46e4`); John Driftmier's successful 2026-04-01 run used the working step-level pattern.

**Fix:** add `GITHUB_TOKEN: ${{ inputs['github-token'] }}` to `runs.env:`. Bracket form because `inputs.github-token` parses as subtraction in expressions.

### claude_max_turns was dead code

Per RFC-096 the agentic tool_use loop runs server-side. The action no longer drives Claude directly. `claudeMaxTurns` had zero consumers in `src/` outside the schema, default, and validation. The validator capped values at 1–20 even though the action.yml default was `'50'` (matching the new server-side cap), producing the spurious warning on every run.

**Removed:** input from `action.yml`, `RSOLV_CLAUDE_MAX_TURNS` from `runs.env`, schema field + default + parsing + validation in `src/config/index.ts`, type field in `src/types/index.ts`. Updated docs (`VALIDATION-TROUBLESHOOTING.md`, `NOT-VALIDATED-RUNBOOK.md`) that advised users to "increase `claude_max_turns`" — turn limit is fixed at 50 server-side and not workflow-tunable.

Existing workflows passing `claude_max_turns:` continue to work; GitHub Actions silently ignores extra `with:` keys.

## Test plan

- [x] New contract test `src/__tests__/action-yml-contract.test.ts` (RED→GREEN) — asserts GITHUB_TOKEN env mapping is present and dead `claude_max_turns` is gone
- [x] `npx tsc --noEmit` — clean
- [x] `vitest run` on action-yml-contract + `src/config/__tests__/index.test.ts` + `src/config/__tests__/timeout.test.ts` — 17/17 passing
- [x] `js-yaml` parse of action.yml confirms structure end-to-end
- [ ] CI green
- [ ] After merge: cut `v4.7.1`, force-move `v4` rolling tag

## Follow-up

Once merged, the rolling `v4` tag must be force-moved to the merge commit so existing `RSOLV-dev/rsolv-action@v4` consumers (Jason, John, others) pick up the fix without changing their workflows.

🤖 Generated with [Claude Code](https://claude.com/claude-code)