### PR TITLE
test: split the AST interpreter spec into per-behaviour examples (1 → 13)

### DIFF
--- a/src/security/__tests__/ast-pattern-interpreter.test.ts
+++ b/src/security/__tests__/ast-pattern-interpreter.test.ts
@@ -1,214 +1,299 @@
-import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
+import { describe, it, expect, afterEach } from 'vitest';
 import { SecurityPattern, VulnerabilityType } from '../types.js';
-import type { ASTPatternInterpreter } from '../ast-pattern-interpreter.js';
-import type { SecurityDetectorV2 } from '../detector-v2.js';
 
-// Union type for cleanup-capable instances
-type CleanupCapable = {
-  cleanup: () => void;
-};
+/**
+ * ASTPatternInterpreter decides whether a vulnerability is reported. Everything
+ * downstream — issue creation, VALIDATE, MITIGATE — is gated on what it returns,
+ * so a silent regression here reads as "the repo is clean" rather than as a
+ * failure.
+ *
+ * These specs are deliberately one-behaviour-per-example. The previous version
+ * packed a true positive and three false positives into a single `it`, so the
+ * first failing expectation hid the other three, and the whole AST safety net
+ * showed up in the suite as a single test.
+ */
 
-// Mock AST pattern with SQL injection detection
-const mockSQLInjectionPattern: SecurityPattern = {
-  id: 'js-sql-injection-concat',
-  name: 'SQL Injection via String Concatenation',
-  type: VulnerabilityType.SQL_INJECTION,
-  severity: 'critical',
-  description: 'SQL injection through string concatenation',
-  patterns: {
-    regex: [/SELECT.*FROM.*\+/i, /INSERT.*VALUES.*\+/i]
-  },
-  languages: ['javascript'],
-  frameworks: [],
-  cweId: 'CWE-89',
-  owaspCategory: 'A03:2021',
-  remediation: 'Use parameterized queries',
-  examples: {
-    vulnerable: 'db.query("SELECT * FROM users WHERE id = " + userId)',
-    secure: 'db.query("SELECT * FROM users WHERE id = ?", [userId])'
-  },
-  // AST Enhancement fields
-  astRules: {
-    node_type: 'BinaryExpression',
-    operator: '+',
-    context_analysis: {
-      contains_sql_keywords: true,
-      has_user_input_in_concatenation: true,
-      within_db_call: true
+type CleanupCapable = { cleanup: () => void };
+
+/**
+ * Factory rather than a shared fixture: each spec states only the attributes it
+ * depends on, so a spec about confidence does not silently rely on someone
+ * else's regex.
+ */
+function sqlInjectionPattern(overrides: Partial<SecurityPattern> = {}): SecurityPattern {
+  return {
+    id: 'js-sql-injection-concat',
+    name: 'SQL Injection via String Concatenation',
+    type: VulnerabilityType.SQL_INJECTION,
+    severity: 'critical',
+    description: 'SQL injection through string concatenation',
+    patterns: { regex: [/SELECT.*FROM.*\+/i, /INSERT.*VALUES.*\+/i] },
+    languages: ['javascript'],
+    frameworks: [],
+    cweId: 'CWE-89',
+    owaspCategory: 'A03:2021',
+    remediation: 'Use parameterized queries',
+    examples: {
+      vulnerable: 'db.query("SELECT * FROM users WHERE id = " + userId)',
+      secure: 'db.query("SELECT * FROM users WHERE id = ?", [userId])'
     },
-    ancestor_requirements: {
-      has_db_method_call: '\\.(?:query|execute|exec|run|all|get)',
-      max_depth: 3
-    }
-  },
-  contextRules: {
-    exclude_paths: ['test/', 'spec/', '__tests__/', 'fixtures/', 'mocks/'],
-    exclude_if_parameterized: true,
-    exclude_if_uses_orm_builder: true,
-    exclude_if_logging_only: true,
-    safe_if_input_validated: true
-  },
-  confidenceRules: {
-    base: 0.3,
-    adjustments: {
-      'direct_req_param_concat': 0.5,
-      'within_db_query_call': 0.3,
-      'has_sql_keywords': 0.2,
-      'uses_parameterized_query': -0.9,
-      'uses_orm_query_builder': -0.8,
-      'is_console_log': -1.0,
-      'has_input_validation': -0.7,
-      'in_test_file': -0.9
-    }
-  },
-  minConfidence: 0.8
-};
+    astRules: {
+      node_type: 'BinaryExpression',
+      operator: '+',
+      context_analysis: {
+        contains_sql_keywords: true,
+        has_user_input_in_concatenation: true,
+        within_db_call: true
+      },
+      ancestor_requirements: {
+        has_db_method_call: '\\.(?:query|execute|exec|run|all|get)',
+        max_depth: 3
+      }
+    },
+    contextRules: {
+      exclude_paths: ['test/', 'spec/', '__tests__/', 'fixtures/', 'mocks/'],
+      exclude_if_parameterized: true,
+      exclude_if_uses_orm_builder: true,
+      exclude_if_logging_only: true,
+      safe_if_input_validated: true
+    },
+    confidenceRules: {
+      base: 0.3,
+      adjustments: {
+        direct_req_param_concat: 0.5,
+        within_db_query_call: 0.3,
+        has_sql_keywords: 0.2,
+        uses_parameterized_query: -0.9,
+        uses_orm_query_builder: -0.8,
+        is_console_log: -1.0,
+        has_input_validation: -0.7,
+        in_test_file: -0.9
+      }
+    },
+    minConfidence: 0.8,
+    ...overrides
+  };
+}
 
-describe('AST Pattern Interpreter', () => {
+const VULNERABLE_QUERY = `
+  const userId = req.params.id;
+  const query = "SELECT * FROM users WHERE id = " + userId;
+  db.query(query, (err, results) => {
+    res.json(results);
+  });
+`;
+
+describe('ASTPatternInterpreter', () => {
   let interpreter: CleanupCapable | null = null;
 
-  afterEach(() => {
-    // Clean up after each test
-    if (interpreter) {
-      interpreter.cleanup();
-    }
-    interpreter = null;
-
-    // Force garbage collection if available
-    if (typeof global !== 'undefined' && 'gc' in global && typeof global.gc === 'function') {
-      global.gc();
-    }
-  });
-
-  it('should use AST rules to reduce false positives in SQL injection detection', async () => {
-    // This test should fail initially because AST interpreter is not integrated
+  async function newInterpreter() {
     const { ASTPatternInterpreter } = await import('../ast-pattern-interpreter.js');
-    interpreter = new ASTPatternInterpreter();
-    
-    // Test case 1: Actual SQL injection vulnerability
-    const vulnerableCode = `
-      const userId = req.params.id;
-      const query = "SELECT * FROM users WHERE id = " + userId;
-      db.query(query, (err, results) => {
-        res.json(results);
-      });
-    `;
-    
-    const vulnerableFindings = await interpreter.scanFile(
-      'api/users.js',
-      vulnerableCode,
-      [mockSQLInjectionPattern]
-    );
+    const instance = new ASTPatternInterpreter();
+    interpreter = instance as unknown as CleanupCapable;
+    return instance;
+  }
 
-    expect(vulnerableFindings.length).toBe(1);
-    expect(vulnerableFindings[0].confidence).toBeGreaterThanOrEqual(0.8);
-
-    // Test case 2: False positive - console.log with SQL
-    const consoleLogCode = `
-      const query = "SELECT * FROM users WHERE id = " + userId;
-      console.log("Query: " + query);
-    `;
-
-    const consoleFindings = await interpreter.scanFile(
-      'debug.js',
-      consoleLogCode,
-      [mockSQLInjectionPattern]
-    );
-
-    // Should not flag console.log as SQL injection
-    expect(consoleFindings.length).toBe(0);
-
-    // Test case 3: False positive - parameterized query
-    const parameterizedCode = `
-      const userId = req.params.id;
-      const query = "SELECT * FROM users WHERE id = ?";
-      db.query(query, [userId], (err, results) => {
-        res.json(results);
-      });
-    `;
-
-    const parameterizedFindings = await interpreter.scanFile(
-      'api/secure-users.js',
-      parameterizedCode,
-      [mockSQLInjectionPattern]
-    );
-
-    // Should not flag parameterized queries
-    expect(parameterizedFindings.length).toBe(0);
-
-    // Test case 4: False positive - test file
-    const testCode = `
-      it('should handle SQL queries', () => {
-        const query = "SELECT * FROM users WHERE id = " + testId;
-        expect(query).toBe(expectedQuery);
-      });
-    `;
-
-    const testFindings = await interpreter.scanFile(
-      '__tests__/user.test.js',
-      testCode,
-      [mockSQLInjectionPattern]
-    );
-
-    // Should not flag test files
-    expect(testFindings.length).toBe(0);
+  afterEach(() => {
+    interpreter?.cleanup();
+    interpreter = null;
   });
 
-  it.skip('should integrate with SecurityDetectorV2 to use AST rules when available', async () => {
-    // SKIPPED: This test causes OOM in shard 14 - moved to ast-pattern-interpreter-memory.test.ts
-    // The issue is that the pattern source creates new instances and fetches patterns repeatedly
-    // causing memory buildup when combined with AST parsing
+  describe('scanFile', () => {
+    describe('when the code concatenates user input into a database query', () => {
+      it('reports the vulnerability', async () => {
+        const subject = await newInterpreter();
 
-    const { SecurityDetectorV2 } = await import('../detector-v2.js');
-    const detector = new SecurityDetectorV2();
+        const findings = await subject.scanFile('api/users.js', VULNERABLE_QUERY, [
+          sqlInjectionPattern()
+        ]);
 
-    // Store detector for cleanup
-    interpreter = detector;
-    
-    // Mock pattern source that returns patterns with AST rules
-    const mockPatternSource = {
-      async getPatternsByLanguage(language: string) {
-        if (language === 'javascript') {
-          return [mockSQLInjectionPattern];
-        }
-        return [];
-      }
-    };
-    
-    // @ts-ignore - accessing private property for testing
-    detector.patternSource = mockPatternSource;
-    
-    // Vulnerable code that should be detected
-    const vulnerableCode = `
-      export function getUserById(req, res) {
-        const userId = req.params.id;
-        const query = "SELECT * FROM users WHERE id = " + userId;
-        db.query(query, (err, results) => {
-          if (err) return res.status(500).json({ error: err });
-          res.json(results);
+        expect(findings).toHaveLength(1);
+      });
+
+      it('reports it with confidence at or above the pattern threshold', async () => {
+        const subject = await newInterpreter();
+
+        const findings = await subject.scanFile('api/users.js', VULNERABLE_QUERY, [
+          sqlInjectionPattern()
+        ]);
+
+        expect(findings[0].confidence).toBeGreaterThanOrEqual(0.8);
+      });
+
+      it('attributes the finding to the pattern that matched', async () => {
+        const subject = await newInterpreter();
+
+        const findings = await subject.scanFile('api/users.js', VULNERABLE_QUERY, [
+          sqlInjectionPattern()
+        ]);
+
+        expect(findings[0].pattern.id).toBe('js-sql-injection-concat');
+      });
+    });
+
+    describe('when the concatenated SQL is only logged', () => {
+      it('does not report it', async () => {
+        const subject = await newInterpreter();
+
+        const findings = await subject.scanFile(
+          'debug.js',
+          `
+            const query = "SELECT * FROM users WHERE id = " + userId;
+            console.log("Query: " + query);
+          `,
+          [sqlInjectionPattern()]
+        );
+
+        expect(findings).toHaveLength(0);
+      });
+    });
+
+    describe('when the query is parameterized', () => {
+      it('does not report it', async () => {
+        const subject = await newInterpreter();
+
+        const findings = await subject.scanFile(
+          'api/secure-users.js',
+          `
+            const userId = req.params.id;
+            const query = "SELECT * FROM users WHERE id = ?";
+            db.query(query, [userId], (err, results) => {
+              res.json(results);
+            });
+          `,
+          [sqlInjectionPattern()]
+        );
+
+        expect(findings).toHaveLength(0);
+      });
+    });
+
+    describe('when the file is a test file', () => {
+      it('does not report vulnerabilities found in it', async () => {
+        const subject = await newInterpreter();
+
+        const findings = await subject.scanFile(
+          '__tests__/user.test.js',
+          VULNERABLE_QUERY,
+          [sqlInjectionPattern()]
+        );
+
+        expect(findings).toHaveLength(0);
+      });
+
+      // Guards the early return in scanFile: test files are skipped by PATH
+      // before any parsing happens, so the exclusion must not depend on the
+      // pattern's own contextRules.
+      it('skips them even when the pattern declares no path exclusions', async () => {
+        const subject = await newInterpreter();
+
+        const findings = await subject.scanFile(
+          'src/api/users.spec.ts',
+          VULNERABLE_QUERY,
+          [sqlInjectionPattern({ contextRules: undefined })]
+        );
+
+        expect(findings).toHaveLength(0);
+      });
+    });
+
+    describe('when no pattern matches the regex pre-filter', () => {
+      it('returns no findings', async () => {
+        const subject = await newInterpreter();
+
+        const findings = await subject.scanFile(
+          'api/users.js',
+          'const total = price + tax;',
+          [sqlInjectionPattern()]
+        );
+
+        expect(findings).toHaveLength(0);
+      });
+    });
+
+    describe('when the JavaScript cannot be parsed', () => {
+      // The parse-failure path must degrade to regex, not throw and abort the
+      // scan — one malformed file should not blind the whole run.
+      it('degrades to the regex fallback instead of throwing', async () => {
+        const subject = await newInterpreter();
+
+        const findings = await subject.scanFile(
+          'api/broken.js',
+          'const query = "SELECT * FROM users WHERE id = " + userId; function ( { { {',
+          [sqlInjectionPattern()]
+        );
+
+        expect(Array.isArray(findings)).toBe(true);
+      });
+    });
+
+    describe('confidence thresholding', () => {
+      // Scored with the adjustments stripped so the confidence is exactly the
+      // declared base. Raising minConfidence on the full pattern proves nothing:
+      // its adjustments saturate the score at 1.0, so every threshold <= 1 lets
+      // it through.
+      const unboostedPattern = (minConfidence: number) =>
+        sqlInjectionPattern({
+          minConfidence,
+          confidenceRules: { base: 0.3, adjustments: {} }
         });
-      }
-    `;
-    
-    const result = await detector.detect(vulnerableCode, 'javascript');
 
-    // Should detect the SQL injection
-    expect(result.length).toBe(1);
-    expect(result[0].type).toBe(VulnerabilityType.SQL_INJECTION);
-    expect(result[0].confidence).toBeGreaterThan(50);
+      it('drops a finding scoring below the pattern threshold', async () => {
+        const subject = await newInterpreter();
 
-    // False positive that should NOT be detected
-    const falsePositiveCode = `
-      export function logQuery(userId) {
-        const query = "SELECT * FROM users WHERE id = " + userId;
-        console.log("Debug query: " + query);
-        // Not executing, just logging
-      }
-    `;
+        const findings = await subject.scanFile('api/users.js', VULNERABLE_QUERY, [
+          unboostedPattern(0.8)
+        ]);
 
-    const fpResult = await detector.detect(falsePositiveCode, 'javascript');
+        expect(findings).toHaveLength(0);
+      });
 
-    // Should NOT detect SQL injection in console.log
-    expect(fpResult.length).toBe(0);
+      it('keeps the same finding when the threshold is at or below its score', async () => {
+        const subject = await newInterpreter();
+
+        const findings = await subject.scanFile('api/users.js', VULNERABLE_QUERY, [
+          unboostedPattern(0.3)
+        ]);
+
+        expect(findings).toHaveLength(1);
+      });
+
+      it('caps confidence at 1.0 however many adjustments apply', async () => {
+        const subject = await newInterpreter();
+
+        const findings = await subject.scanFile('api/users.js', VULNERABLE_QUERY, [
+          sqlInjectionPattern()
+        ]);
+
+        expect(findings[0].confidence).toBeLessThanOrEqual(1);
+      });
+    });
+
+    describe('AST traversal', () => {
+      /**
+       * Smoke test that traversal actually reaches nodes: confidence is
+       * accumulated DURING traversal from AST context, so a score above the
+       * declared base (0.3) can only come from visitors having fired. A
+       * traversal that silently visited nothing would return the bare base.
+       *
+       * Scope note, so nobody mistakes this for more than it is: this does NOT
+       * detect a cross-major @babel/parser-vs-traverse mismatch. That was
+       * measured, not assumed — reinstalling parser 8 against traverse/types 7
+       * leaves all of these specs green, because traverse 7 reads Babel 8 ASTs
+       * fine (verified for template literals, private fields, static blocks and
+       * optional chaining). Aligning the Babel majors is still correct hygiene,
+       * but it fixed a latent inconsistency, not an observed detection failure.
+       */
+      it('reaches AST nodes rather than silently visiting none', async () => {
+        const subject = await newInterpreter();
+
+        const findings = await subject.scanFile('api/users.js', VULNERABLE_QUERY, [
+          sqlInjectionPattern()
+        ]);
+
+        expect(findings).toHaveLength(1);
+        expect(findings[0].confidence).toBeGreaterThan(0.3);
+      });
+    });
   });
 });


### PR DESCRIPTION
`ASTPatternInterpreter` decides whether a vulnerability is reported — issue creation, VALIDATE and MITIGATE are all gated on what it returns — and it had **one passing assertion** guarding it.

The coverage wasn't so much absent as unreadable: a true positive and three false positives were packed into a single `it`, so the first failing expectation hid the other three, and the entire AST safety net surfaced in the suite as one test.

Split per the project's betterspecs conventions — describe the unit, context the scenario, one behaviour per example, factory over shared fixture so each spec states only the attributes it depends on.

## New coverage for branches nothing exercised

- test files skipped by **path**, independent of the pattern's `contextRules`
- regex pre-filter returning no candidates
- unparseable JavaScript degrading to the regex fallback instead of throwing
- confidence thresholding, both directions
- confidence capping at 1.0

## Two expectations written from measurement, after the first draft of each was wrong

**Confidence saturates at 1.0** on this pattern, so raising `minConfidence` to 0.99 filters nothing — my first threshold spec passed for the wrong reason. The threshold specs now strip the adjustments so the score is exactly the declared base (verified: 0.3 in, 0.3 out).

**The "traversal integrity" spec does *not* detect a cross-major Babel mismatch.** I reinstalled the skew from #332 (`parser@8.0.4` + `traverse@7.29.8` + `types@7.29.8`) and all 13 specs stayed green. Direct probing confirms traverse 7 reads Babel 8 ASTs fine:

```json
{"ok":true,"counts":{"classes":1,"privateProp":1,"staticBlock":1,"optionalMember":2}}
```

The comment now states what the spec actually proves — that visitors fire at all — and explicitly disclaims the rest, so nobody trusts it for more than it does.

## That corrects #332

Its body claimed the skew risked *missed detections*. That was a mechanism I asserted and never verified. Aligning the Babel majors was still right — a package family split across majors is a genuine latent hazard — but it fixed a latent inconsistency, **not an observed failure**. Corrected on that PR too.

A test named for a guarantee it doesn't provide is worse than no test, which is the whole reason this file needed work.

13 tests pass; `tsc` and lint clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)